### PR TITLE
JBIDE-12955 fix relativepath

### DIFF
--- a/archives/pom.xml
+++ b/archives/pom.xml
@@ -5,7 +5,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>archives</artifactId>

--- a/as/pom.xml
+++ b/as/pom.xml
@@ -5,7 +5,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>as</artifactId>

--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>jmx</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../build/parent/pom.xml</relativePath>
+		<relativePath>../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>server.all</artifactId>


### PR DESCRIPTION
I suggest we don't use the root of "uber" components as the parent since components like central would overlap in naming and maven in central is not really a child of central. WDYT ?
