### PR TITLE
fix pom hierarchy for server component

### DIFF
--- a/all-tests/pom.xml
+++ b/all-tests/pom.xml
@@ -4,11 +4,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>server.all</artifactId>
+		<artifactId>server</artifactId>
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
-	<groupId>org.jboss.tools</groupId>
-	<artifactId>server.all.tests</artifactId>
+	<groupId>org.jboss.tools.server<groupId>
+	<artifactId>all-tests</artifactId>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/archives/pom.xml
+++ b/archives/pom.xml
@@ -3,9 +3,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>parent</artifactId>
-		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
+		<artifactId>server</artifactId>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>archives</artifactId>

--- a/as/pom.xml
+++ b/as/pom.xml
@@ -3,9 +3,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>parent</artifactId>
-		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
+		<artifactId>server</artifactId>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>as</artifactId>

--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -4,9 +4,8 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>parent</artifactId>
-		<version>4.0.0.Beta2-SNAPSHOT</version>
-		<relativePath>../../jbosstools-build/parent/pom.xml</relativePath>
+		<artifactId>server</artifactId>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>jmx</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<relativePath>../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
-	<artifactId>server.all</artifactId>
+	<artifactId>server</artifactId>
 	<version>4.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<modules>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -4,11 +4,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jboss.tools</groupId>
-		<artifactId>server.all</artifactId>
+		<artifactId>server</artifactId>
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
-	<groupId>org.jboss.tools</groupId>
-	<artifactId>server.site</artifactId>
+	<groupId>org.jboss.tools.server</groupId>
+	<artifactId>site</artifactId>
 	<packaging>eclipse-repository</packaging>
 
 	<properties>


### PR DESCRIPTION
artifactIds cleaned up from "all", references to parent pom.xml removed
from sub components and replaced with reference to sever/pomm.xml
