### PR TITLE
JBIDE-13012 - EAP 5.2 cannot be added using runtime detection

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/runtime/JBossASHandler.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/runtime/JBossASHandler.java
@@ -92,8 +92,10 @@ public class JBossASHandler extends AbstractRuntimeDetectorDelegate implements I
 	private static File getLocation(RuntimeDefinition runtimeDefinitions) {
 		String type = runtimeDefinitions.getType();
 		String version = runtimeDefinitions.getVersion();
-		if (EAP.equals(type) && version != null && version.startsWith("6") ) {//$NON-NLS-1$
-			return runtimeDefinitions.getLocation();
+		if (EAP.equals(type) && version != null) {
+			if (version.startsWith("6") || version.startsWith("5.2")) {//$NON-NLS-1$ //$NON-NLS-2$
+				return runtimeDefinitions.getLocation();
+			}
 		}
 		if (SOA_P.equals(type) || EAP.equals(type) || EPP.equals(type)) {
 			return new File(runtimeDefinitions.getLocation(), "jboss-as");//$NON-NLS-1$

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/JBossServerType.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/JBossServerType.java
@@ -266,6 +266,7 @@ public class JBossServerType implements IJBossToolingConstants {
 			if( V4_3.equals(version)) return IJBossToolingConstants.SERVER_EAP_43;
 			if( V5_0.equals(version)) return IJBossToolingConstants.SERVER_EAP_50;
 			if( V5_1.equals(version)) return IJBossToolingConstants.SERVER_EAP_50;
+			if( V5_2.equals(version)) return IJBossToolingConstants.SERVER_EAP_50;
 			if( V6_0.equals(version)) return IJBossToolingConstants.SERVER_EAP_60;
 			return null;
 		}


### PR DESCRIPTION
EAP 5.2 cannot be added using runtime detection
