### PR TITLE
JBIDE-13420 added missing descriptionURL attribute to feature.properties

### DIFF
--- a/as/features/org.jboss.ide.eclipse.as.test.feature/feature.properties
+++ b/as/features/org.jboss.ide.eclipse.as.test.feature/feature.properties
@@ -22,6 +22,7 @@ providerName=JBoss by Red Hat
 
 # "description" property - description of the feature
 description=Provides WTP server adapters for JBoss installations. These adapters are capable of deployment and providing classpaths for projects. Zipped or exploded deployments, JMX integration, and other extensions are included.
+descriptionURL=http://www.jboss.org/tools
 
 # "copyright" property - text of the "Feature Update Copyright"
 copyright=Copyright (c) 2008-2012 Red Hat, Inc. and others.\n\


### PR DESCRIPTION
added missing attribute to feature.properties to make it work with tycho 0.17.0
