### PR TITLE
JBIDE-13517 - Runtime detection doesn't recognize EAP 6.1.0

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/JBossServerType.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/JBossServerType.java
@@ -270,6 +270,7 @@ public class JBossServerType implements IJBossToolingConstants {
 			if( V5_2.equals(version)) return IJBossToolingConstants.SERVER_EAP_50;
 			if( V5_3.equals(version)) return IJBossToolingConstants.SERVER_EAP_50;
 			if( V6_0.equals(version)) return IJBossToolingConstants.SERVER_EAP_60;
+			if( V6_1.equals(version)) return IJBossToolingConstants.SERVER_EAP_60;
 			return null;
 		}
 	}


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-13517
Runtime detection doesn't recognize EAP 6.1.0
