### PR TITLE
Some files are missing copyright header

### DIFF
--- a/archives/plugins/org.jboss.ide.eclipse.archives.core/src/main/org/jboss/ide/eclipse/archives/core/model/IArchiveDeltaFactory.java
+++ b/archives/plugins/org.jboss.ide.eclipse.archives.core/src/main/org/jboss/ide/eclipse/archives/core/model/IArchiveDeltaFactory.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.core.model;
 
 public interface IArchiveDeltaFactory {

--- a/archives/plugins/org.jboss.ide.eclipse.archives.core/src/main/org/jboss/ide/eclipse/archives/core/model/IArchiveNodeFactory.java
+++ b/archives/plugins/org.jboss.ide.eclipse.archives.core/src/main/org/jboss/ide/eclipse/archives/core/model/IArchiveNodeFactory.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.core.model;
 
 import java.util.HashMap;

--- a/archives/plugins/org.jboss.ide.eclipse.archives.core/src/main/org/jboss/ide/eclipse/archives/core/model/IArchiveStandardFileSet.java
+++ b/archives/plugins/org.jboss.ide.eclipse.archives.core/src/main/org/jboss/ide/eclipse/archives/core/model/IArchiveStandardFileSet.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.core.model;
 
 public interface IArchiveStandardFileSet extends IArchiveFileSet {

--- a/archives/plugins/org.jboss.ide.eclipse.archives.jdt.integration/src/org/jboss/ide/eclipse/archives/jdt/integration/ArchiveJDTIntegrationPlugin.java
+++ b/archives/plugins/org.jboss.ide.eclipse.archives.jdt.integration/src/org/jboss/ide/eclipse/archives/jdt/integration/ArchiveJDTIntegrationPlugin.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.jdt.integration;
 
 import org.eclipse.jdt.ui.JavaUI;

--- a/archives/plugins/org.jboss.ide.eclipse.archives.jdt.integration/src/org/jboss/ide/eclipse/archives/jdt/integration/model/DeltaLibFileset.java
+++ b/archives/plugins/org.jboss.ide.eclipse.archives.jdt.integration/src/org/jboss/ide/eclipse/archives/jdt/integration/model/DeltaLibFileset.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.jdt.integration.model;
 
 import org.eclipse.core.runtime.IPath;

--- a/archives/plugins/org.jboss.ide.eclipse.archives.jdt.integration/src/org/jboss/ide/eclipse/archives/jdt/integration/model/LibFileSetNodeProvider.java
+++ b/archives/plugins/org.jboss.ide.eclipse.archives.jdt.integration/src/org/jboss/ide/eclipse/archives/jdt/integration/model/LibFileSetNodeProvider.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.jdt.integration.model;
 
 import java.util.HashMap;

--- a/archives/plugins/org.jboss.ide.eclipse.archives.jdt.integration/src/org/jboss/ide/eclipse/archives/jdt/integration/ui/JDTArchivesActionProvider.java
+++ b/archives/plugins/org.jboss.ide.eclipse.archives.jdt.integration/src/org/jboss/ide/eclipse/archives/jdt/integration/ui/JDTArchivesActionProvider.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.jdt.integration.ui;
 
 import org.eclipse.jdt.ui.JavaUI;

--- a/archives/plugins/org.jboss.ide.eclipse.archives.ui/src/main/org/jboss/ide/eclipse/archives/ui/actions/DisableHandler.java
+++ b/archives/plugins/org.jboss.ide.eclipse.archives.ui/src/main/org/jboss/ide/eclipse/archives/ui/actions/DisableHandler.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.ui.actions;
 
 import org.eclipse.core.commands.AbstractHandler;

--- a/archives/plugins/org.jboss.ide.eclipse.archives.ui/src/main/org/jboss/ide/eclipse/archives/ui/actions/EnableHandler.java
+++ b/archives/plugins/org.jboss.ide.eclipse.archives.ui/src/main/org/jboss/ide/eclipse/archives/ui/actions/EnableHandler.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.ui.actions;
 
 import org.eclipse.core.commands.AbstractHandler;

--- a/archives/tests/org.jboss.ide.eclipse.archives.test/inputs/projects/GenericProject/src/org/jboss/ide/eclipse/archives/test/ClassOne.java
+++ b/archives/tests/org.jboss.ide.eclipse.archives.test/inputs/projects/GenericProject/src/org/jboss/ide/eclipse/archives/test/ClassOne.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.test;
 
 public class ClassOne {

--- a/archives/tests/org.jboss.ide.eclipse.archives.test/inputs/projects/GenericProject/src/org/jboss/ide/eclipse/archives/test/ClassTwo.java
+++ b/archives/tests/org.jboss.ide.eclipse.archives.test/inputs/projects/GenericProject/src/org/jboss/ide/eclipse/archives/test/ClassTwo.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.test;
 
 public class ClassTwo {

--- a/archives/tests/org.jboss.ide.eclipse.archives.test/inputs/projects/GenericProject/src/org/jboss/ide/eclipse/archives/test/inner/ClassThree.java
+++ b/archives/tests/org.jboss.ide.eclipse.archives.test/inputs/projects/GenericProject/src/org/jboss/ide/eclipse/archives/test/inner/ClassThree.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.test.inner;
 
 public class ClassThree {

--- a/archives/tests/org.jboss.ide.eclipse.archives.test/inputs/projects/GenericProject/src/org/jboss/ide/eclipse/archives/test/inner/Messages.java
+++ b/archives/tests/org.jboss.ide.eclipse.archives.test/inputs/projects/GenericProject/src/org/jboss/ide/eclipse/archives/test/inner/Messages.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.test.inner;
 
 public class Messages {

--- a/archives/tests/org.jboss.ide.eclipse.archives.test/src/org/jboss/ide/eclipse/archives/test/model/DirectoryScannerTest.java
+++ b/archives/tests/org.jboss.ide.eclipse.archives.test/src/org/jboss/ide/eclipse/archives/test/model/DirectoryScannerTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.test.model;
 
 import java.io.File;

--- a/archives/tests/org.jboss.ide.eclipse.archives.test/src/org/jboss/ide/eclipse/archives/test/model/FilesetMatchesPathTest.java
+++ b/archives/tests/org.jboss.ide.eclipse.archives.test/src/org/jboss/ide/eclipse/archives/test/model/FilesetMatchesPathTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.test.model;
 
 import org.eclipse.core.resources.IFile;

--- a/archives/tests/org.jboss.ide.eclipse.archives.test/src/org/jboss/ide/eclipse/archives/test/model/ReadWriteTest.java
+++ b/archives/tests/org.jboss.ide.eclipse.archives.test/src/org/jboss/ide/eclipse/archives/test/model/ReadWriteTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.test.model;
 
 import java.util.List;

--- a/archives/tests/org.jboss.ide.eclipse.archives.ui.test/src/org/jboss/ide/eclipse/archives/ui/test/ArchivesUITestSuite.java
+++ b/archives/tests/org.jboss.ide.eclipse.archives.ui.test/src/org/jboss/ide/eclipse/archives/ui/test/ArchivesUITestSuite.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.ui.test;
 
 import junit.framework.Test;

--- a/archives/tests/org.jboss.ide.eclipse.archives.ui.test/src/org/jboss/ide/eclipse/archives/ui/test/preferences/MainPreferencePageTest.java
+++ b/archives/tests/org.jboss.ide.eclipse.archives.ui.test/src/org/jboss/ide/eclipse/archives/ui/test/preferences/MainPreferencePageTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.ui.test.preferences;
 
 import junit.framework.TestCase;

--- a/archives/tests/org.jboss.ide.eclipse.archives.ui.test/src/org/jboss/ide/eclipse/archives/ui/test/views/ProjectsArchiveViewTest.java
+++ b/archives/tests/org.jboss.ide.eclipse.archives.ui.test/src/org/jboss/ide/eclipse/archives/ui/test/views/ProjectsArchiveViewTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.ui.test.views;
 
 import org.eclipse.ui.IPageLayout;

--- a/archives/tests/org.jboss.ide.eclipse.archives.ui.test/src/org/jboss/ide/eclipse/archives/ui/test/wizards/FilesetWizardTest.java
+++ b/archives/tests/org.jboss.ide.eclipse.archives.ui.test/src/org/jboss/ide/eclipse/archives/ui/test/wizards/FilesetWizardTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.ui.test.wizards;
 
 import junit.framework.TestCase;

--- a/archives/tests/org.jboss.ide.eclipse.archives.ui.test/src/org/jboss/ide/eclipse/archives/ui/test/wizards/NewJARWizardTest.java
+++ b/archives/tests/org.jboss.ide.eclipse.archives.ui.test/src/org/jboss/ide/eclipse/archives/ui/test/wizards/NewJARWizardTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.ui.test.wizards;
 
 import junit.framework.TestCase;

--- a/archives/util/packaging-convert/src/org/jboss/tools/archives/JBossIDEtoTools.java
+++ b/archives/util/packaging-convert/src/org/jboss/tools/archives/JBossIDEtoTools.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.archives;
 
 import java.io.IOException;

--- a/as/plugins/org.jboss.ide.eclipse.archives.webtools/src/org/jboss/ide/eclipse/archives/webtools/SharedImages.java
+++ b/as/plugins/org.jboss.ide.eclipse.archives.webtools/src/org/jboss/ide/eclipse/archives/webtools/SharedImages.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.webtools;
 
 import java.util.Hashtable;

--- a/as/plugins/org.jboss.ide.eclipse.archives.webtools/src/org/jboss/ide/eclipse/archives/webtools/modules/OSGiPublisher.java
+++ b/as/plugins/org.jboss.ide.eclipse.archives.webtools/src/org/jboss/ide/eclipse/archives/webtools/modules/OSGiPublisher.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.webtools.modules;
 
 import org.eclipse.core.resources.IProject;

--- a/as/plugins/org.jboss.ide.eclipse.archives.webtools/src/org/jboss/ide/eclipse/archives/webtools/ui/FilesetReferenceWizardFragment.java
+++ b/as/plugins/org.jboss.ide.eclipse.archives.webtools/src/org/jboss/ide/eclipse/archives/webtools/ui/FilesetReferenceWizardFragment.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.archives.webtools.ui;
 
 import org.eclipse.core.resources.IProject;

--- a/as/plugins/org.jboss.ide.eclipse.as.classpath.core/src/org/jboss/ide/eclipse/as/classpath/core/Messages.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.classpath.core/src/org/jboss/ide/eclipse/as/classpath/core/Messages.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.classpath.core;
 
 import org.eclipse.osgi.util.NLS;

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/extensions/events/DeprecatedEclipseLog.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/extensions/events/DeprecatedEclipseLog.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.extensions.events;
 
 import java.io.*;

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/modules/SingleDeployableWorkspaceListener.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/modules/SingleDeployableWorkspaceListener.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.modules;
 
 import java.util.ArrayList;

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/runtime/DownloadRuntimeToWTPRuntime.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/runtime/DownloadRuntimeToWTPRuntime.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.runtime;
 
 import java.util.ArrayList;

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/AbstractDeploymentScannerAdditions.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/AbstractDeploymentScannerAdditions.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.server.internal;
 
 import java.util.ArrayList;

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/BehaviourModel.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/BehaviourModel.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.server.internal;
 
 import java.util.ArrayList;

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBoss72Eap61DefaultLaunchArguments.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBoss72Eap61DefaultLaunchArguments.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.server.internal.extendedproperties;
 
 import org.eclipse.wst.server.core.IRuntime;

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossEAP61ExtendedProperties.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossEAP61ExtendedProperties.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.server.internal.extendedproperties;
 
 import org.eclipse.core.runtime.IAdaptable;

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/util/LaunchConfigUtils.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/util/LaunchConfigUtils.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.util;
 
 import java.io.File;

--- a/as/plugins/org.jboss.ide.eclipse.as.dmr/src/org/jboss/ide/eclipse/as/dmr/Activator.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.dmr/src/org/jboss/ide/eclipse/as/dmr/Activator.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.dmr;
 
 import org.eclipse.core.runtime.Plugin;

--- a/as/plugins/org.jboss.ide.eclipse.as.management.as71/src/org/jboss/ide/eclipse/as/internal/management/as71/AS71ManagementActivator.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.management.as71/src/org/jboss/ide/eclipse/as/internal/management/as71/AS71ManagementActivator.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.internal.management.as71;
 
 import org.eclipse.core.runtime.Plugin;

--- a/as/plugins/org.jboss.ide.eclipse.as.management.core/src/org/jboss/ide/eclipse/as/management/core/AS7ManagementActivator.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.management.core/src/org/jboss/ide/eclipse/as/management/core/AS7ManagementActivator.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.management.core;
 
 import org.eclipse.jface.resource.ImageDescriptor;

--- a/as/plugins/org.jboss.ide.eclipse.as.management.core/src/org/jboss/ide/eclipse/as/management/core/IAS7ManagementDetails.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.management.core/src/org/jboss/ide/eclipse/as/management/core/IAS7ManagementDetails.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.management.core;
 
 import org.eclipse.wst.server.core.IServer;

--- a/as/plugins/org.jboss.ide.eclipse.as.rse.ui/src/org/jboss/ide/eclipse/as/rse/ui/RSEBrowseBehavior.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.rse.ui/src/org/jboss/ide/eclipse/as/rse/ui/RSEBrowseBehavior.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.rse.ui;
 
 import org.eclipse.core.runtime.NullProgressMonitor;

--- a/as/plugins/org.jboss.ide.eclipse.as.rse.ui/src/org/jboss/ide/eclipse/as/rse/ui/RSEExploreBehavior.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.rse.ui/src/org/jboss/ide/eclipse/as/rse/ui/RSEExploreBehavior.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.rse.ui;
 
 import org.eclipse.core.runtime.CoreException;

--- a/as/plugins/org.jboss.ide.eclipse.as.rse.ui/src/org/jboss/ide/eclipse/as/rse/ui/RSEUIMessages.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.rse.ui/src/org/jboss/ide/eclipse/as/rse/ui/RSEUIMessages.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.rse.ui;
 
 import org.eclipse.osgi.util.NLS;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui.mbeans/src/org/jboss/ide/eclipse/as/ui/mbeans/packages/NewSARAction.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui.mbeans/src/org/jboss/ide/eclipse/as/ui/mbeans/packages/NewSARAction.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.mbeans.packages;
 
 

--- a/as/plugins/org.jboss.ide.eclipse.as.ui.mbeans/src/org/jboss/ide/eclipse/as/ui/mbeans/project/SARVirtualComponent.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui.mbeans/src/org/jboss/ide/eclipse/as/ui/mbeans/project/SARVirtualComponent.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.mbeans.project;
 
 import org.eclipse.core.resources.IProject;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui.mbeans/src/org/jboss/ide/eclipse/as/ui/mbeans/project/SarArtifactAdapter.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui.mbeans/src/org/jboss/ide/eclipse/as/ui/mbeans/project/SarArtifactAdapter.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.mbeans.project;
 
 import org.eclipse.core.resources.IProject;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui.mbeans/src/org/jboss/ide/eclipse/as/ui/mbeans/project/SarProjectRuntimeChangedDelegate.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui.mbeans/src/org/jboss/ide/eclipse/as/ui/mbeans/project/SarProjectRuntimeChangedDelegate.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.mbeans.project;
 
 import org.eclipse.core.resources.IProject;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/FormUtils.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/FormUtils.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui;
 
 import org.eclipse.swt.widgets.Composite;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/actions/ServerActionMessages.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/actions/ServerActionMessages.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.actions;
 
 import org.eclipse.osgi.util.NLS;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/marker/ConfigureRuntimeMarkerResolution.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/marker/ConfigureRuntimeMarkerResolution.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.marker;
 
 import org.eclipse.core.resources.IMarker;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/marker/MarkerResolutionGenerator.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/marker/MarkerResolutionGenerator.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.marker;
 
 import org.eclipse.core.resources.IMarker;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/AbstractEntry.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/AbstractEntry.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.views;
 
 import java.io.PrintWriter;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/EventDetailsDialog.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/EventDetailsDialog.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.views;
 
 import java.io.IOException;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/Group.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/Group.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.views;
 
 import java.io.PrintWriter;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/LogEntry.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/LogEntry.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.views;
 
 import java.io.PrintWriter;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/LogLabelProvider.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/LogLabelProvider.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.views;
 
 import java.text.MessageFormat;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/LogReader.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/LogReader.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.views;
 
 import java.io.BufferedReader;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/LogSession.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/LogSession.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.views;
 
 import java.io.PrintWriter;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/ServerLogView.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/ServerLogView.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.views;
 
 import java.io.BufferedReader;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/server/extensions/ModuleActionProvider.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/server/extensions/ModuleActionProvider.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.views.server.extensions;
 
 import java.util.ArrayList;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/server/extensions/ModulePublishDecorator.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/server/extensions/ModulePublishDecorator.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.views.server.extensions;
 
 import org.eclipse.core.runtime.IStatus;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/server/extensions/ServerLogActionProvider.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/server/extensions/ServerLogActionProvider.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.views.server.extensions;
 
 import org.eclipse.core.runtime.NullProgressMonitor;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/server/extensions/XPathActionProvider.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/server/extensions/XPathActionProvider.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.views.server.extensions;
 
 import org.eclipse.core.filesystem.EFS;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/server/extensions/XPathDecorator.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/server/extensions/XPathDecorator.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.views.server.extensions;
 
 import org.eclipse.jface.viewers.IDecoration;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/server/extensions/XPathTreeContentProvider.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/server/extensions/XPathTreeContentProvider.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.views.server.extensions;
 
 import java.util.ArrayList;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/server/extensions/XPathTreeLabelProvider.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/views/server/extensions/XPathTreeLabelProvider.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.views.server.extensions;
 
 import java.text.MessageFormat;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/wizards/JBoss72Eap61RuntimeWizardFragment.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/wizards/JBoss72Eap61RuntimeWizardFragment.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.wizards;
 
 import org.jboss.ide.eclipse.as.core.server.bean.JBossServerType;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/wizards/JBossASDownloadRuntimeFilter.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/wizards/JBossASDownloadRuntimeFilter.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.wizards;
 
 import java.util.Arrays;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/xpl/JavaMainTabClone.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/xpl/JavaMainTabClone.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.xpl;
 
 import java.lang.reflect.InvocationTargetException;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/IDefaultLaunchArguments.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/IDefaultLaunchArguments.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.server;
 
 import java.util.HashMap;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/IDelegatingServerBehavior.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/IDelegatingServerBehavior.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.server;
 
 import org.eclipse.core.runtime.IStatus;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/IDeployableServerBehaviour.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/IDeployableServerBehaviour.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.server;
 
 import org.eclipse.wst.server.core.IModule;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/IJBossLaunchDelegate.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/IJBossLaunchDelegate.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.server;
 
 import org.eclipse.core.runtime.CoreException;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/IJBossServer.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/IJBossServer.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.server;
 
 public interface IJBossServer extends IDeployableServer {

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/ILaunchConfigConfigurator.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/ILaunchConfigConfigurator.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.server;
 
 import org.eclipse.core.runtime.CoreException;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/IServerStatePollerType.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/IServerStatePollerType.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.server;
 
 

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/util/ExpressionResolverUtil.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/util/ExpressionResolverUtil.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.util;
 
 import java.io.File;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/util/LocalCopyCallback.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/util/LocalCopyCallback.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.util;
 
 import java.io.File;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/util/ModuleResourceUtil.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/util/ModuleResourceUtil.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.util;
 
 import java.io.File;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/util/ProgressMonitorUtil.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/util/ProgressMonitorUtil.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.util;
 
 import org.eclipse.core.runtime.IProgressMonitor;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/util/RuntimeUtils.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/util/RuntimeUtils.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.util;
 
 import org.eclipse.core.runtime.CoreException;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/util/CustomProjectInEarWorkaroundUtil.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/util/CustomProjectInEarWorkaroundUtil.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.wtp.core.util;
 
 import java.util.ArrayList;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/util/ResourceFilter.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/util/ResourceFilter.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.wtp.core.util;
 
 import org.eclipse.core.resources.IResource;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/vcf/JBTHeirarchyParticipantProvider.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/vcf/JBTHeirarchyParticipantProvider.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.wtp.core.vcf;
 
 import java.util.Properties;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/vcf/VCFClasspathCommand.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/vcf/VCFClasspathCommand.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.wtp.core.vcf;
 
 import java.util.ArrayList;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/src/org/jboss/ide/eclipse/as/wtp/ui/Messages.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/src/org/jboss/ide/eclipse/as/wtp/ui/Messages.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.wtp.ui;
 
 import org.eclipse.osgi.util.NLS;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/src/org/jboss/ide/eclipse/as/wtp/ui/WTPOveridePlugin.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/src/org/jboss/ide/eclipse/as/wtp/ui/WTPOveridePlugin.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.wtp.ui;
 
 import java.net.MalformedURLException;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/src/org/jboss/ide/eclipse/as/wtp/ui/wizards/xpl/export/FullPublishToServerWizard.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/src/org/jboss/ide/eclipse/as/wtp/ui/wizards/xpl/export/FullPublishToServerWizard.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.wtp.ui.wizards.xpl.export;
 
 import java.util.List;

--- a/as/tests/org.jboss.ide.eclipse.as.archives.integration.test/src/org/jboss/ide/eclipse/as/archives/integration/test/BuildDeployTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.archives.integration.test/src/org/jboss/ide/eclipse/as/archives/integration/test/BuildDeployTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.archives.integration.test;
 
 import java.io.BufferedInputStream;

--- a/as/tests/org.jboss.ide.eclipse.as.archives.integration.test/src/org/jboss/ide/eclipse/as/archives/integration/test/JSTEarWithNestedWebProjectIncrementalPublish.java
+++ b/as/tests/org.jboss.ide.eclipse.as.archives.integration.test/src/org/jboss/ide/eclipse/as/archives/integration/test/JSTEarWithNestedWebProjectIncrementalPublish.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.archives.integration.test;
 
 import java.io.IOException;

--- a/as/tests/org.jboss.ide.eclipse.as.archives.integration.test/src/org/jboss/ide/eclipse/as/archives/integration/test/SingleFileZippedDeploymentIntegrationTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.archives.integration.test/src/org/jboss/ide/eclipse/as/archives/integration/test/SingleFileZippedDeploymentIntegrationTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.archives.integration.test;
 
 import java.io.File;

--- a/as/tests/org.jboss.ide.eclipse.as.archives.integration.test/src/org/jboss/ide/eclipse/as/archives/integration/test/ZippedFilterTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.archives.integration.test/src/org/jboss/ide/eclipse/as/archives/integration/test/ZippedFilterTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.archives.integration.test;
 
 import java.io.File;

--- a/as/tests/org.jboss.ide.eclipse.as.test/projects/JBIDE2512b-ejb/ejbModule/my/bean/Tiger.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/projects/JBIDE2512b-ejb/ejbModule/my/bean/Tiger.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package my.bean;
 
 import javax.ejb.Remote;

--- a/as/tests/org.jboss.ide.eclipse.as.test/projects/JBIDE2512b-ejb/ejbModule/my/bean/TigerBean.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/projects/JBIDE2512b-ejb/ejbModule/my/bean/TigerBean.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package my.bean;
 
 import javax.ejb.Stateless;

--- a/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/defects/WebDeployableArtifactUtilDefectTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/defects/WebDeployableArtifactUtilDefectTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.test.defects;
 
 import java.io.ByteArrayInputStream;

--- a/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/projectcreation/NewTargetedWebProjectTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/projectcreation/NewTargetedWebProjectTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.test.projectcreation;
 
 /******************************************************************************* 

--- a/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/DeployAndTempDeployFolderTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/DeployAndTempDeployFolderTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.test.publishing;
 
 import junit.framework.TestCase;

--- a/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/v2/BehaviourModelDefectTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/v2/BehaviourModelDefectTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.test.publishing.v2;
 
 import org.eclipse.core.runtime.CoreException;

--- a/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/v2/Mock2BehaviourDelegate.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/v2/Mock2BehaviourDelegate.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.test.publishing.v2;
 
 import org.eclipse.wst.server.core.IModule;

--- a/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/v2/Mock2FilterTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/v2/Mock2FilterTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.test.publishing.v2;
 
 import java.io.IOException;

--- a/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/v2/MockJSTPublisherTestDynUtil.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/v2/MockJSTPublisherTestDynUtil.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.test.publishing.v2;
 /******************************************************************************* 
  * Copyright (c) 2011 Red Hat, Inc. 

--- a/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/v2/PublishFilterDirectoryScannerTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/v2/PublishFilterDirectoryScannerTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.test.publishing.v2;
 
 import java.io.File;

--- a/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/v2/PublishingFilterTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/v2/PublishingFilterTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.test.publishing.v2;
 
 import java.io.IOException;

--- a/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/v2/SingleFileDeployableMockDeploymentTester.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/v2/SingleFileDeployableMockDeploymentTester.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.test.publishing.v2;
 
 /******************************************************************************* 

--- a/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/v2/StandaloneUtilProjectPublish.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/publishing/v2/StandaloneUtilProjectPublish.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.test.publishing.v2;
 
 import java.io.IOException;

--- a/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/server/ServerBeanLoaderTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/server/ServerBeanLoaderTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.test.server;
 
 import junit.framework.TestCase;

--- a/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/server/ServerSecureStorageTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/server/ServerSecureStorageTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.test.server;
 
 import junit.framework.TestCase;

--- a/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/server/SimpleServerImplTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/server/SimpleServerImplTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.test.server;
 
 import junit.framework.TestCase;

--- a/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/server/StringSubstitutionTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/server/StringSubstitutionTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.test.server;
 
 import junit.framework.TestCase;

--- a/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/util/ExpressionResolverUtilTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.test/src/org/jboss/ide/eclipse/as/test/util/ExpressionResolverUtilTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.test.util;
 
 import org.jboss.ide.eclipse.as.core.util.ExpressionResolverUtil;

--- a/as/tests/org.jboss.ide.eclipse.as.ui.test/src/org/jboss/ide/eclipse/as/ui/test/AsUiAllTests.java
+++ b/as/tests/org.jboss.ide.eclipse.as.ui.test/src/org/jboss/ide/eclipse/as/ui/test/AsUiAllTests.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.test;
 
 import org.jboss.ide.eclipse.as.ui.wizards.test.NewServerWizardTest;

--- a/as/tests/org.jboss.ide.eclipse.as.ui.test/src/org/jboss/ide/eclipse/as/ui/test/ServerModeUIExtensionTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.ui.test/src/org/jboss/ide/eclipse/as/ui/test/ServerModeUIExtensionTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.test;
 
 import java.util.Collection;

--- a/as/tests/org.jboss.ide.eclipse.as.ui.test/src/org/jboss/ide/eclipse/as/ui/wizards/test/NewServerWizardTest.java
+++ b/as/tests/org.jboss.ide.eclipse.as.ui.test/src/org/jboss/ide/eclipse/as/ui/wizards/test/NewServerWizardTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.ide.eclipse.as.ui.wizards.test;
 
 import java.io.PrintWriter;

--- a/as/tests/org.jboss.tools.as.test.core/projects/JBIDE2512b-ejb/ejbModule/my/bean/Tiger.java
+++ b/as/tests/org.jboss.tools.as.test.core/projects/JBIDE2512b-ejb/ejbModule/my/bean/Tiger.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package my.bean;
 
 import javax.ejb.Remote;

--- a/as/tests/org.jboss.tools.as.test.core/projects/JBIDE2512b-ejb/ejbModule/my/bean/TigerBean.java
+++ b/as/tests/org.jboss.tools.as.test.core/projects/JBIDE2512b-ejb/ejbModule/my/bean/TigerBean.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package my.bean;
 
 import javax.ejb.Stateless;

--- a/as/tests/org.jboss.tools.as.test.core/projects/UserForum1EJB1/ejbModule/my/pack/TigerBean.java
+++ b/as/tests/org.jboss.tools.as.test.core/projects/UserForum1EJB1/ejbModule/my/pack/TigerBean.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package my.pack;
 
 import javax.ejb.Remote;

--- a/as/tests/org.jboss.tools.as.test.core/projects/UserForum1EJB1/ejbModule/my/pack/TigerBeanBean.java
+++ b/as/tests/org.jboss.tools.as.test.core/projects/UserForum1EJB1/ejbModule/my/pack/TigerBeanBean.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package my.pack;
 
 import javax.ejb.Stateless;

--- a/as/tests/org.jboss.tools.as.test.core/projects/UserForum1Util1/src/util/pack/MyModel.java
+++ b/as/tests/org.jboss.tools.as.test.core/projects/UserForum1Util1/src/util/pack/MyModel.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package util.pack;
 
 public class MyModel {

--- a/as/tests/org.jboss.tools.as.test.core/projects/UserForum1Util2/src/utilweb/pack/UtilWebModel.java
+++ b/as/tests/org.jboss.tools.as.test.core/projects/UserForum1Util2/src/utilweb/pack/UtilWebModel.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package utilweb.pack;
 
 public class UtilWebModel {

--- a/as/tests/org.jboss.tools.as.test.core/projects/UserForum1Web1/src/dweb1/serv/WebMe1.java
+++ b/as/tests/org.jboss.tools.as.test.core/projects/UserForum1Web1/src/dweb1/serv/WebMe1.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package dweb1.serv;
 
 import java.io.IOException;

--- a/as/tests/org.jboss.tools.as.test.core/projects/UserForum1Web2/src/web2/serv/Web2Servlet.java
+++ b/as/tests/org.jboss.tools.as.test.core/projects/UserForum1Web2/src/web2/serv/Web2Servlet.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package web2.serv;
 
 import java.io.IOException;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/ASMatrixTests.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/ASMatrixTests.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core;
 
 import java.io.File;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/ASToolsTestSuite.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/ASToolsTestSuite.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core;
 
 import org.jboss.tools.as.test.core.classpath.ClasspathSuite;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/TestConstants.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/TestConstants.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core;
 
 import java.util.HashMap;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/classpath/ClasspathSuite.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/classpath/ClasspathSuite.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.classpath;
 
 import org.junit.runner.RunWith;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/classpath/EJB3SupportVerifierTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/classpath/EJB3SupportVerifierTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.classpath;
 
 import java.util.Collection;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/internal/utils/BundleUtils.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/internal/utils/BundleUtils.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.internal.utils;
 
 import java.io.File;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/internal/utils/ComponentReferenceUtils.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/internal/utils/ComponentReferenceUtils.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.internal.utils;
 
 import java.util.Arrays;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/internal/utils/MatrixUtils.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/internal/utils/MatrixUtils.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.internal.utils;
 
 import java.util.ArrayList;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/internal/utils/ResourceUtils.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/internal/utils/ResourceUtils.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.internal.utils;
 
 import java.io.ByteArrayInputStream;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/internal/utils/ServerCreationTestUtils.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/internal/utils/ServerCreationTestUtils.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.internal.utils;
 
 import java.io.File;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/internal/utils/ServerParameterUtils.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/internal/utils/ServerParameterUtils.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.internal.utils;
 
 import java.util.ArrayList;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/CreateRuntimeTwiceTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/CreateRuntimeTwiceTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server;
 
 import java.util.Collection;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/CreateServerCheckDefaultsTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/CreateServerCheckDefaultsTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server;
 
 import java.io.File;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/Ear50CreationTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/Ear50CreationTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server;
 
 import java.util.Collection;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/ParametizedSuite.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/ParametizedSuite.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server;
 
 import org.jboss.tools.as.test.core.launch.DeploymentScannerAdditionsTest;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/ServerBeanLoader3Test.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/ServerBeanLoader3Test.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server;
 
 import java.io.File;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/ServerHomeTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/ServerHomeTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server;
 
 import java.io.File;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/ServerParameterUtils.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/ServerParameterUtils.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server;
 
 

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/ServerTypeDefaultClasspathEntriesTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/ServerTypeDefaultClasspathEntriesTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server;
 
 import java.util.ArrayList;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/WebDeployableArtifactUtilDefectTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/WebDeployableArtifactUtilDefectTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server;
 
 import java.net.URL;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/XPathModelTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/XPathModelTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server;
 
 import java.io.File;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/AbstractComponentPublishingTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/AbstractComponentPublishingTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server.publishing;
 
 import java.util.Collection;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/AbstractPublishingTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/AbstractPublishingTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server.publishing;
 
 import java.io.File;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/PublishingSuite.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/PublishingSuite.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server.publishing;
 
 import org.jboss.tools.as.test.core.parametized.server.publishing.defect.PublishDefectSuite;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/SingleDeployableFileTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/SingleDeployableFileTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server.publishing;
 
 import java.io.File;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/SingleDeployableFolderTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/SingleDeployableFolderTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server.publishing;
 
 import java.io.File;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/defect/PublishDefectSuite.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/defect/PublishDefectSuite.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server.publishing.defect;
 
 import org.jboss.tools.as.test.core.parametized.server.publishing.defect.RepublishDefectTest;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/defect/PublishWeb2DeletesWeb1LibsTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/defect/PublishWeb2DeletesWeb1LibsTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server.publishing.defect;
 
 import junit.framework.TestCase;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/sar/JBossSarProjectCreationTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/sar/JBossSarProjectCreationTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server.publishing.sar;
 
 import java.io.ByteArrayInputStream;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/sar/SarModuleTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/publishing/sar/SarModuleTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.parametized.server.publishing.sar;
 
 import java.util.ArrayList;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/polling/AbstractTestInternalPoller.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/polling/AbstractTestInternalPoller.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.polling;
 
 import java.util.List;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/polling/DummyYesOrNoPoller.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/polling/DummyYesOrNoPoller.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.polling;
 
 import java.util.List;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/polling/PollThreadTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/polling/PollThreadTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.polling;
 
 import java.util.Arrays;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/polling/PollerFailureHandler.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/polling/PollerFailureHandler.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.polling;
 
 import java.util.List;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/polling/TestInternalPoller.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/polling/TestInternalPoller.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.polling;
 
 import java.util.List;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/utiltests/ConfigNameResolverTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/utiltests/ConfigNameResolverTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.utiltests;
 
 import java.util.Collection;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/utiltests/ExpressionResolverUtilTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/utiltests/ExpressionResolverUtilTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.utiltests;
 
 import junit.framework.TestCase;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/utiltests/RSEUtilsTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/utiltests/RSEUtilsTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.utiltests;
 
 import java.util.ArrayList;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/utiltests/UnitedServerListenerTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/utiltests/UnitedServerListenerTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.utiltests;
 
 import junit.framework.TestCase;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/utiltests/UtilsSuite.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/utiltests/UtilsSuite.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.utiltests;
 
 import org.junit.runner.RunWith;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/utiltests/VersionStringUtilTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/utiltests/VersionStringUtilTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.as.test.core.utiltests;
 
 import junit.framework.TestCase;


### PR DESCRIPTION
Searched in eclipse as \A(\s|package) and replaced with copyright text
