### PR TITLE
JBIDE-15156 : add minimal ui deps for tomcat detection

### DIFF
--- a/wtp/features/org.jboss.tools.wtp.runtimes.tomcat.feature/feature.xml
+++ b/wtp/features/org.jboss.tools.wtp.runtimes.tomcat.feature/feature.xml
@@ -25,12 +25,22 @@ Raleigh NC 27606 USA.
    </license>
 
    <requires>
-      <import feature="org.jboss.tools.runtime.core.feature"/>
+      <import feature="org.jboss.tools.runtime.core.feature" version="2.0.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.core.runtime"/>
+      <import plugin="org.jboss.tools.runtime.core"/>
+      <import plugin="org.eclipse.wst.server.core"/>
+      <import plugin="org.eclipse.core.resources"/>
+      <import plugin="org.eclipse.jst.server.tomcat.core" version="1.1.400" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.jdt.launching"/>
+      <import plugin="org.eclipse.jst.server.core" version="1.2.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.jst.server.tomcat.ui" version="1.1.300" match="greaterOrEqual"/>
    </requires>
+
    <plugin
          id="org.jboss.tools.wtp.runtimes.tomcat"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+
 </feature>

--- a/wtp/features/org.jboss.tools.wtp.runtimes.tomcat.feature/pom.xml
+++ b/wtp/features/org.jboss.tools.wtp.runtimes.tomcat.feature/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion> 
+	<modelVersion>4.0.0</modelVersion>
 	<parent>
 	  <groupId>org.jboss.tools.wtp</groupId>
 	  <artifactId>features</artifactId>
 	   <version>1.0.0-SNAPSHOT</version>
 	</parent>
-	<artifactId>org.jboss.tools.wtp.runtimes.tomcat.feature</artifactId> 
+    <groupId>org.jboss.tools.wtp.features</groupId>
+	<artifactId>org.jboss.tools.wtp.runtimes.tomcat.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	
+
 </project>

--- a/wtp/plugins/org.jboss.tools.wtp.runtimes.tomcat/META-INF/MANIFEST.MF
+++ b/wtp/plugins/org.jboss.tools.wtp.runtimes.tomcat/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.jst.server.tomcat.core;bundle-version="1.1.400",
  org.eclipse.jdt.launching,
- org.eclipse.jst.server.core;bundle-version="1.2.0"
+ org.eclipse.jst.server.core;bundle-version="1.2.0",
+ org.eclipse.jst.server.tomcat.ui;bundle-version="1.1.300"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: %BundleVendor


### PR DESCRIPTION
- added org.eclipse.jst.server.tomcat.ui dependency to org.jboss.tools.wtp.runtimes.tomcat/META-INF/MANIFEST.MF, so that no missing icons show up in preferences > servers runtime environments
- added computed plugins from org.eclipse.jst.server_ui.feature to org.jboss.tools.wtp.runtimes.tomcat.feature/feature.xml, so the server view shows up and servers can be actually used (started/stopped). Adding org.eclipse.jst.server_ui.feature to features.xml made tycho ignore the locally built org.jboss.tools.wtp.runtimes.tomcat.feature in the local p2 site, for some reason.
- fixed groupid of org.jboss.tools.wtp.runtimes.tomcat.feature

Signed-off-by: Fred Bricon fbricon@gmail.com
