### PR TITLE
JBIDE-15310 explicit jpp6.1 support DEPENDS ON PULL 120

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/JBossServerType.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/JBossServerType.java
@@ -43,6 +43,7 @@ public class JBossServerType implements IJBossToolingConstants {
 	public static final JBossServerType EAP61 = new ServerBeanTypeEAP61();
 	public static final JBossServerType WILDFLY80 = new ServerBeanTypeWildfly80();
 	public static final JBossServerType JPP6 = new ServerBeanTypeJPP6();
+	public static final JBossServerType JPP61 = new ServerBeanTypeJPP61();
 	public static final JBossServerType UNKNOWN_AS71_PRODUCT = new ServerBeanTypeUnknownAS71Product();	
 	public static final JBossServerType SOA6 = new ServerBeanTypeSOA6();; 
 	public static final JBossServerType SOAP = new ServerBeanTypeSOAP(); 

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanLoader.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanLoader.java
@@ -27,6 +27,7 @@ public class ServerBeanLoader {
 		JBossServerType.WILDFLY80, 
 		JBossServerType.EAP61,
 		JBossServerType.SOA6,
+		JBossServerType.JPP61, 
 		JBossServerType.UNKNOWN_AS72_PRODUCT,
 		JBossServerType.AS72, 
 		JBossServerType.JPP6, 

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeJPP61.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeJPP61.java
@@ -1,0 +1,34 @@
+/******************************************************************************* 
+ * Copyright (c) 2013 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.ide.eclipse.as.core.server.bean;
+
+import java.io.File;
+
+import org.jboss.ide.eclipse.as.core.server.bean.ServerBeanTypeUnknownAS72Product.UnknownAS72ProductServerTypeCondition;
+
+public class ServerBeanTypeJPP61 extends ServerBeanTypeUnknownAS71Product {
+	public ServerBeanTypeJPP61() {
+		super("JPP", "JBoss Portal Platform", 
+				asPath("modules","system","layers","base","org","jboss","as","server","main"),
+				new String[] { V6_1 },
+				new JPP61Condition());
+	}
+	public static class JPP61Condition extends UnknownAS72ProductServerTypeCondition {
+		@Override
+		public boolean isServerRoot(File location) {
+			if( "JPP".equalsIgnoreCase(getSlot(location))) {
+				String v = getFullVersion(location, null);
+				return v != null && v.startsWith(V6_1);
+			}
+			return false;
+		}
+	}
+}

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeUnknownAS71Product.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeUnknownAS71Product.java
@@ -28,9 +28,13 @@ public class ServerBeanTypeUnknownAS71Product extends JBossServerType {
 	}
 	
 	protected ServerBeanTypeUnknownAS71Product(String id, String desc, String path, Condition condition) {
-		super( id, desc, path, new String[]{}, condition);
+		this( id, desc, path, new String[]{}, condition);
 	}
 	
+	protected ServerBeanTypeUnknownAS71Product(String id, String desc, String path, 
+			String[] version, Condition condition) {
+		super( id, desc, path, version, condition);
+	}
 	
 	public static class UnknownAS71ProductServerTypeCondition extends org.jboss.ide.eclipse.as.core.server.bean.ServerBeanTypeEAP6.EAP6ServerTypeCondition {
 		@Override

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/ServerBeanLoader3Test.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/ServerBeanLoader3Test.java
@@ -87,7 +87,7 @@ public class ServerBeanLoader3Test extends TestCase {
 		expected.put(ServerCreationTestUtils.TEST_SERVER_TYPE_GATEIN_35, new Data(JBossServerType.AS7GateIn, IJBossToolingConstants.V3_5));
 		expected.put(ServerCreationTestUtils.TEST_SERVER_TYPE_GATEIN_36, new Data(JBossServerType.AS7GateIn, "3.6"));
 		expected.put(ServerCreationTestUtils.TEST_SERVER_TYPE_JPP_60, new Data(JBossServerType.JPP6, "6.0"));
-		expected.put(ServerCreationTestUtils.TEST_SERVER_TYPE_JPP_61, new Data(JBossServerType.UNKNOWN_AS72_PRODUCT, "6.1", "JPP"));
+		expected.put(ServerCreationTestUtils.TEST_SERVER_TYPE_JPP_61, new Data(JBossServerType.JPP61, "6.1", "JPP"));
 		// NEW_SERVER_ADAPTER
 	}
 	

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/ServerBeanRuntimeMatcherTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/ServerBeanRuntimeMatcherTest.java
@@ -89,7 +89,7 @@ public class ServerBeanRuntimeMatcherTest extends TestCase {
 		expected.put(ServerCreationTestUtils.TEST_SERVER_TYPE_GATEIN_35, new Data(JBossServerType.AS7GateIn, IJBossToolingConstants.V3_5));
 		expected.put(ServerCreationTestUtils.TEST_SERVER_TYPE_GATEIN_36, new Data(JBossServerType.AS7GateIn, "3.6"));
 		expected.put(ServerCreationTestUtils.TEST_SERVER_TYPE_JPP_60, new Data(JBossServerType.JPP6, "6.0"));
-		expected.put(ServerCreationTestUtils.TEST_SERVER_TYPE_JPP_61, new Data(JBossServerType.UNKNOWN_AS72_PRODUCT, "6.1", "JPP"));
+		expected.put(ServerCreationTestUtils.TEST_SERVER_TYPE_JPP_61, new Data(JBossServerType.JPP61, "6.1", "JPP"));
 		// NEW_SERVER_ADAPTER
 	}
 


### PR DESCRIPTION
First commit is from PR 120. This is necessary because the unit test for this issue was updated in PR 120. 
