### PR TITLE
Adding decorator JBIDE-14728

### DIFF
--- a/jmx/plugins/org.jboss.tools.jmx.ui/plugin.xml
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/plugin.xml
@@ -262,4 +262,24 @@
          </wizardPage>
       </providerUI>
    </extension>
+   
+   
+   	<!-- Decorator for connected / disconnected -->
+	<extension point="org.eclipse.ui.decorators">
+      <decorator
+            class="org.jboss.tools.jmx.ui.internal.views.navigator.JMXConnectionDecorator"
+            id="org.jboss.tools.jmx.ui.internal.views.navigator.JMXConnectionDecorator"
+            label="JMX Connection Decorator"
+            lightweight="true"
+            location="BOTTOM_RIGHT"
+            state="true">
+         <enablement>
+            <or>
+               <objectClass name="org.jboss.tools.jmx.core.IConnectionWrapper"/>
+            </or>
+         </enablement>
+      </decorator>
+   </extension>
+   
+   
 </plugin>

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/Messages.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/Messages.java
@@ -90,6 +90,9 @@ public class Messages extends NLS {
 	public static String Loading;
 	public static String ErrorLoading;
 	public static String UpdatingSelectionJob;
+	
+	public static String StateConnected;
+	public static String StateDisconnected;
 
 	public static String JMXUIImageDescriptorNotFound;
 	

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/Messages.properties
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/Messages.properties
@@ -80,3 +80,5 @@ ErrorLoading=Error loading JMX Nodes
 UpdatingSelectionJob=Updating selection job
 
 JMXUIImageDescriptorNotFound=Unable to load image {0} from plugin {1}
+StateConnected=   [Connected]
+StateDisconnected=   [Disconnected]

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/views/navigator/JMXConnectionDecorator.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/views/navigator/JMXConnectionDecorator.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat Inc. 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    "Rob Stryker" <rob.stryker@redhat.com> - Initial implementation
+ *******************************************************************************/
+package org.jboss.tools.jmx.ui.internal.views.navigator;
+
+import org.eclipse.jface.viewers.IDecoration;
+import org.eclipse.jface.viewers.ILightweightLabelDecorator;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.jboss.tools.jmx.core.IConnectionWrapper;
+import org.jboss.tools.jmx.ui.Messages;
+
+public class JMXConnectionDecorator extends LabelProvider implements ILightweightLabelDecorator {
+	public void decorate(Object element, IDecoration decoration) {
+		String decoration2 = getDecoration(element);
+		if( decoration2 != null ) {
+			decoration.addSuffix(decoration2);
+		}
+	}
+	
+	public static String getDecoration(Object element) {
+		String ret = null;
+		if( element instanceof IConnectionWrapper) {
+			boolean connected = ((IConnectionWrapper)element).isConnected();
+			return connected ? Messages.StateConnected : Messages.StateDisconnected;
+		}
+		return ret;
+	}
+}


### PR DESCRIPTION
A decorator was requested next to each top-level element in the MBean Explorer to indicate its connection status. This patch accomplishes that goal. There are no API considerations. 
