### PR TITLE
JBIDE-14818 - moderate refactor to allow openshift to use the composite ...

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/Messages.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/Messages.java
@@ -240,7 +240,12 @@ public class Messages extends NLS {
 	public static String EditorLocalDeployment;
 	public static String EditorRefreshViewer;
 	public static String EditorDeploymentPageWarning;
-	
+	public static String EditorDeploymentPageFilterBy;
+	public static String EditorDeploymentPageFilterAll;
+	public static String EditorDeploymentPageFilterDeployable;
+	public static String EditorDeploymentPageFilterDeployed;
+	public static String EditorDeploymentPageFilterModuleName;
+
 	
 	public static String ExploreUtils_Action_Text;
 	public static String ExploreUtils_Description;

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/Messages.properties
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/Messages.properties
@@ -215,6 +215,14 @@ EditorNoRuntimeSelected=No Runtime Selected. Please select a runtime and refresh
 EditorLocalDeployment=Local Deployment
 EditorRefreshViewer=Refresh Table
 EditorDeploymentPageWarning=Settings on this page may only be modified if the server has 0 modules and is fully synchronized.
+EditorDeploymentPageFilterBy=Filter by:
+EditorDeploymentPageFilterAll=All
+EditorDeploymentPageFilterDeployable=Deployable
+EditorDeploymentPageFilterDeployed=Deployed
+EditorDeploymentPageFilterModuleName=By Module Name
+
+
+
 ExploreUtils_Action_Text=File Browser
 ExploreUtils_Description=Explore deploy directory
 

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/editor/DeploymentModuleOptionCompositeAssistant.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/editor/DeploymentModuleOptionCompositeAssistant.java
@@ -15,39 +15,26 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.jface.viewers.CellEditor;
-import org.eclipse.jface.viewers.ICellModifier;
-import org.eclipse.jface.viewers.ILabelProvider;
-import org.eclipse.jface.viewers.ILabelProviderListener;
-import org.eclipse.jface.viewers.ITableLabelProvider;
-import org.eclipse.jface.viewers.ITreeContentProvider;
-import org.eclipse.jface.viewers.TextCellEditor;
-import org.eclipse.jface.viewers.TreeViewer;
-import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.FormLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
-import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Text;
-import org.eclipse.swt.widgets.TreeColumn;
-import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.forms.IFormColors;
 import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.forms.widgets.FormToolkit;
@@ -56,7 +43,6 @@ import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IRuntime;
 import org.eclipse.wst.server.core.IServer;
 import org.eclipse.wst.server.core.IServerWorkingCopy;
-import org.eclipse.wst.server.ui.ServerUICore;
 import org.eclipse.wst.server.ui.internal.command.ServerCommand;
 import org.jboss.ide.eclipse.as.core.ExtensionManager;
 import org.jboss.ide.eclipse.as.core.JBossServerCorePlugin;
@@ -68,17 +54,34 @@ import org.jboss.ide.eclipse.as.core.server.IJBossServerPublisher;
 import org.jboss.ide.eclipse.as.core.server.IJBossServerRuntime;
 import org.jboss.ide.eclipse.as.core.server.internal.ExtendedServerPropertiesAdapterFactory;
 import org.jboss.ide.eclipse.as.core.server.internal.extendedproperties.ServerExtendedProperties;
-import org.jboss.ide.eclipse.as.core.util.DeploymentPreferenceLoader.DeploymentModulePrefs;
-import org.jboss.ide.eclipse.as.core.util.DeploymentPreferenceLoader.DeploymentPreferences;
 import org.jboss.ide.eclipse.as.core.util.IJBossRuntimeResourceConstants;
 import org.jboss.ide.eclipse.as.core.util.IJBossToolingConstants;
 import org.jboss.ide.eclipse.as.core.util.ServerAttributeHelper;
 import org.jboss.ide.eclipse.as.core.util.ServerConverter;
 import org.jboss.ide.eclipse.as.core.util.ServerUtil;
 import org.jboss.ide.eclipse.as.ui.Messages;
-import org.jboss.ide.eclipse.as.ui.UIUtil;
 
-public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeListener {
+/**
+ * This class is now effectively a composite, despite its poor naming. 
+ * The naming is historical and cannot be changed at this time. 
+ * 
+ * This class is not intended to be instantiated or used by clients, except for
+ * the legacy case of adding a mapping.  Once that use-case is removed or changed, 
+ * this class may be removed, renamed,  or modified heavily. 
+ * 
+ */
+public class DeploymentModuleOptionCompositeAssistant extends Composite implements PropertyChangeListener {
+	
+	/*
+	 * This interface is unfortunately insufficient for the needs of all use-cases. 
+	 * The methods seem tailored to pre-as7 servers. 
+	 * The addMapping method is called directly from the rse-ui bundle's start() method. 
+	 * 
+	 * So it's insufficient from both an app-server version methodology and also 
+	 * from an API standpoint it's bad. 
+	 * 
+	 * This class can be renamed 
+	 */
 	public static interface IDeploymentPageCallback {
 		public void propertyChange(PropertyChangeEvent evt, DeploymentModuleOptionCompositeAssistant composite);
 		public String getServerLocation(IServerWorkingCopy wc);
@@ -109,8 +112,7 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 
 		public void propertyChange(PropertyChangeEvent evt,
 				DeploymentModuleOptionCompositeAssistant composite) {
-			// TODO Auto-generated method stub
-			
+			// do nothing for now, but can later respond to changes as needed
 		}
 	}
 	
@@ -122,50 +124,33 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 		return beh.openBrowseDialog(page.getServer(), original);
 	}
 
-	// Combo strings - TODO extract to messages
-	private static final String ALL = "All";
-	private static final String DEPLOYABLE = "Deployable";
-	private static final String DEPLOYED = "Deployed";
-	private static final String BY_MODNAME = "By Module Name";
-	private static final String BY_MODTYPE = "By Module Type";
-	
-	
-	protected static final String COLUMN_NAME = IJBossToolingConstants.LOCAL_DEPLOYMENT_NAME;
-	protected static final String COLUMN_LOC = IJBossToolingConstants.LOCAL_DEPLOYMENT_LOC;
-	protected static final String COLUMN_TEMP_LOC = IJBossToolingConstants.LOCAL_DEPLOYMENT_TEMP_LOC;
-	protected static final String OUTPUT_NAME = IJBossToolingConstants.LOCAL_DEPLOYMENT_OUTPUT_NAME;
 	protected static final String MAIN = LocalPublishMethod.LOCAL_PUBLISH_METHOD;
 	private ModuleDeploymentPage page;
-	private DeploymentPreferences preferences;
-	private TreeViewer viewer;
 	private Text deployText, tempDeployText;
-	private Button metadataRadio, serverRadio, customRadio, currentSelection;
+	private Button metadataRadio, serverRadio, customRadio, currentRadioSelection;
 	private Button deployButton, tempDeployButton;
 	private ModifyListener deployListener, tempDeployListener;
 	private SelectionListener radioListener, zipListener;
 	private Button zipDeployWTPProjects;
 	private String lastCustomDeploy, lastCustomTemp;
 	
-	private Combo filterCombo; 
-	private Text filterText;
 	
+	// Poorly named, but, after certain events, any widget in this list
+	// may have its 'enabled' status tweaked based on shouldEnableControl
+	private ArrayList<Control> enableDisableWidgets = new ArrayList<Control>();
 
 	
 	private IServerWorkingCopy lastWC;
 	
-	public DeploymentModuleOptionCompositeAssistant() {
+	public DeploymentModuleOptionCompositeAssistant(Composite parent, ModuleDeploymentPage page) {
+		super(parent, SWT.NONE);
+		this.page = page;
+		setLayout(new FillLayout());
+		createDefaultComposite(this);
 	}
 
 	public ModuleDeploymentPage getPage() {
 		return page;
-	}
-	
-	public void setDeploymentPage(ModuleDeploymentPage page) {
-		this.page = page;
-	}
-
-	public void setDeploymentPrefs(DeploymentPreferences prefs) {
-		this.preferences = prefs;
 	}
 
 	protected ServerAttributeHelper getHelper() {
@@ -185,7 +170,7 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 	}
 
 	public Button getSelectedRadio() {
-		return currentSelection;
+		return currentRadioSelection;
 	}
 	
 	protected boolean shouldCreateMetadataRadio() {
@@ -201,6 +186,9 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 	}
 
 	protected boolean shouldEnableMetadataRadio() {
+		if( !shouldCreateMetadataRadio())
+			return false;
+		
 		String mode = getHelper().getAttribute(IDeployableServer.SERVER_MODE, LocalPublishMethod.LOCAL_PUBLISH_METHOD); 
 		if(!LocalPublishMethod.LOCAL_PUBLISH_METHOD.equals(mode))
 			return false;
@@ -215,10 +203,10 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 		return true;
 	}
 
-	protected Composite createDefaultComposite(Composite parent) {
-
-		FormToolkit toolkit = new FormToolkit(parent.getDisplay());
-
+	/*
+	 * Subclasses may override to change text strings
+	 */
+	protected Section createSection(FormToolkit toolkit, Composite parent) {
 		Section section = toolkit.createSection(parent,
 				ExpandableComposite.TWISTIE | ExpandableComposite.EXPANDED
 						| ExpandableComposite.TITLE_BAR);
@@ -226,35 +214,77 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 		section.setToolTipText(Messages.swf_DeploymentDescription);
 		section.setLayoutData(new GridData(GridData.FILL_HORIZONTAL
 				| GridData.VERTICAL_ALIGN_FILL));
-
-		Composite composite = toolkit.createComposite(section);
-
-		composite.setLayout(new FormLayout());
-
+		return section;
+	}
+	
+	/*
+	 * Subclasses may override to change text labels
+	 */
+	protected Control createDescriptionLabel(FormToolkit toolkit, Composite composite) {
 		Label descriptionLabel = toolkit.createLabel(composite,
 				Messages.swf_DeploymentDescriptionLabel);
 		descriptionLabel.setToolTipText(Messages.swf_DeploymentDescription);
-		Control top = descriptionLabel;
-		FormData descriptionLabelData = new FormData();
-		descriptionLabelData.left = new FormAttachment(0, 5);
-		descriptionLabelData.top = new FormAttachment(0, 5);
-		descriptionLabel.setLayoutData(descriptionLabelData);
+		return descriptionLabel;
+	}
+	
+	/*
+	 * This creates the top half of the page. Specifically, 
+	 * the deploy and tmp deploy fields, the radios (metadata, server, custom), 
+	 * the 'should zip' checkbox, etc. 
+	 */
+	
+	protected Composite createDefaultComposite(Composite parent) {
+
+		lastWC = page.getServer();
+		lastWC.addPropertyChangeListener(this);
+
+		FormToolkit toolkit = new FormToolkit(parent.getDisplay());
+		Section section = createSection(toolkit, parent);
+		Composite composite = toolkit.createComposite(section);
+		composite.setLayout(new FormLayout());
+
+		createDefaultCompositeContents(toolkit, composite);
+
+		toolkit.paintBordersFor(composite);
+		section.setClient(composite);
+		page.getSaveStatus();
+		updateWidgets();
+		return section;
+	}
+	
+	protected void createDefaultCompositeContents(FormToolkit toolkit, Composite composite) {
+		Control top = createDescriptionLabel(toolkit, composite);
+		if( top != null ) {
+			FormData fd1 = new FormData();
+			fd1.left = new FormAttachment(0, 5);
+			fd1.top = new FormAttachment(0, 5);
+			top.setLayoutData(fd1);
+		}
+		
 		if( getShowRadios() ) {
 			Composite inner = addRadios(toolkit, composite);
 			FormData radios = new FormData();
-			radios.top = new FormAttachment(descriptionLabel, 5);
+			radios.top = new FormAttachment(top, 5);
 			radios.left = new FormAttachment(0, 5);
 			radios.right = new FormAttachment(100, -5);
 			inner.setLayoutData(radios);
 			top = inner;
 		}
-		lastWC = page.getServer();
-		lastWC.addPropertyChangeListener(this);
 		
 		if( showTempAndDeployTexts() ) {
 			top = addTempAndDeployTexts(toolkit, composite, top);
 		}
 		
+		if( showZipWidgets()) {
+			addZipWidgets(toolkit, composite, top);
+		}
+	}
+	
+	protected boolean showZipWidgets() {
+		return true;
+	}
+	
+	protected Control addZipWidgets(FormToolkit toolkit, Composite composite, Control top) {
 		zipDeployWTPProjects = toolkit.createButton(composite,
 				Messages.EditorZipDeployments, SWT.CHECK);
 		boolean zippedPublisherAvailable = isZippedPublisherAvailable(); 
@@ -278,28 +308,10 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 			}
 		};
 		zipDeployWTPProjects.addSelectionListener(zipListener);
-
-		toolkit.paintBordersFor(composite);
-		section.setClient(composite);
-		page.getSaveStatus();
-		updateWidgets();
-		return section;
+		return zipDeployWTPProjects;
 	}
 	
 	protected Composite addRadios(FormToolkit toolkit, Composite parent) {
-		Composite inner = toolkit.createComposite(parent);
-		inner.setLayout(new GridLayout(1, false));
-
-		if( shouldCreateMetadataRadio() )
-			metadataRadio = toolkit.createButton(inner,
-					Messages.EditorUseWorkspaceMetadata, SWT.RADIO);
-		if( shouldCreateServerRadio())
-			serverRadio = toolkit.createButton(inner,
-					Messages.EditorUseServersDeployFolder, SWT.RADIO);
-		if( shouldCreateCustomRadio())
-			customRadio = toolkit.createButton(inner,
-					Messages.EditorUseCustomDeployFolder, SWT.RADIO);
-
 		radioListener = new SelectionListener() {
 			public void widgetDefaultSelected(SelectionEvent e) {
 				widgetSelected(e);
@@ -309,14 +321,29 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 				radioSelected(e.getSource());
 			}
 		};
-		if( shouldCreateMetadataRadio())
+
+		Composite inner = toolkit.createComposite(parent);
+		inner.setLayout(new GridLayout(1, false));
+
+		if( shouldCreateMetadataRadio() ) {
+			metadataRadio = toolkit.createButton(inner,
+					Messages.EditorUseWorkspaceMetadata, SWT.RADIO);
 			metadataRadio.addSelectionListener(radioListener);
-		if( shouldCreateServerRadio())
+			metadataRadio.setEnabled(shouldEnableMetadataRadio());
+			enableDisableWidgets.add(metadataRadio);
+		}
+		if( shouldCreateServerRadio()) {
+			serverRadio = toolkit.createButton(inner,
+					Messages.EditorUseServersDeployFolder, SWT.RADIO);
 			serverRadio.addSelectionListener(radioListener);
-		if( shouldCreateCustomRadio()) 
+			enableDisableWidgets.add(serverRadio);
+		}
+		if( shouldCreateCustomRadio()) {
+			customRadio = toolkit.createButton(inner,
+					Messages.EditorUseCustomDeployFolder, SWT.RADIO);
 			customRadio.addSelectionListener(radioListener);
-		
-		metadataRadio.setEnabled(shouldEnableMetadataRadio());
+			enableDisableWidgets.add(customRadio);
+		}
 		return inner;
 	}
 	
@@ -326,6 +353,7 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 		label.setForeground(toolkit.getColors().getColor(IFormColors.TITLE));
 		
 		deployText = toolkit.createText(parent, getDeployDir(), SWT.BORDER);
+		enableDisableWidgets.add(deployText);
 		deployListener = new ModifyListener() {
 			public void modifyText(ModifyEvent e) {
 				page.execute(new SetDeployDirCommand());
@@ -333,8 +361,9 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 		};
 		deployText.addModifyListener(deployListener);
 
-		deployButton = toolkit.createButton(parent, Messages.browse,
-				SWT.PUSH);
+		deployButton = toolkit.createButton(parent, Messages.browse, SWT.PUSH);
+		enableDisableWidgets.add(deployButton);
+
 		deployButton.addSelectionListener(new SelectionListener() {
 			public void widgetDefaultSelected(SelectionEvent e) {
 			}
@@ -352,8 +381,9 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 		tempDeployLabel.setForeground(toolkit.getColors().getColor(
 				IFormColors.TITLE));
 
-		tempDeployText = toolkit.createText(parent, getTempDeployDir(),
-				SWT.BORDER);
+		tempDeployText = toolkit.createText(parent, getTempDeployDir(), SWT.BORDER);
+		enableDisableWidgets.add(tempDeployText);
+
 		tempDeployListener = new ModifyListener() {
 			public void modifyText(ModifyEvent e) {
 				page.execute(new SetTempDeployDirCommand());
@@ -361,8 +391,9 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 		};
 		tempDeployText.addModifyListener(tempDeployListener);
 
-		tempDeployButton = toolkit.createButton(parent, Messages.browse,
-				SWT.PUSH);
+		tempDeployButton = toolkit.createButton(parent, Messages.browse,SWT.PUSH);
+		enableDisableWidgets.add(tempDeployButton);
+
 		tempDeployButton.addSelectionListener(new SelectionListener() {
 			public void widgetDefaultSelected(SelectionEvent e) {
 			}
@@ -434,7 +465,7 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 				customRadio.setSelection(getDeployType().equals(
 						IDeployableServer.DEPLOY_CUSTOM));
 			
-			currentSelection = metadataRadio != null && metadataRadio.getSelection() ? metadataRadio
+			currentRadioSelection = metadataRadio != null && metadataRadio.getSelection() ? metadataRadio
 					: serverRadio != null && serverRadio.getSelection() ? serverRadio : customRadio;
 		}
 		
@@ -463,22 +494,11 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 		}
 	}
 	
-	protected boolean shouldEnableControl(Control c) {
-		if( c == null || c.isDisposed())
-			return false;
-		
-		if( c == deployText || c == tempDeployText || c == deployButton || c == tempDeployButton)
-			return getDeployType().equals(IDeployableServer.DEPLOY_CUSTOM);
-		if( c == metadataRadio)
-			return shouldEnableMetadataRadio();
-		return true;
-	}
-	
 	public void radioSelected(Object c) {
-		if (c == currentSelection)
+		if (c == currentRadioSelection)
 			return; // do nothing
-		page.execute(new RadioClickedCommand((Button)c, currentSelection));
-		currentSelection = (Button)c;
+		page.execute(new RadioClickedCommand((Button)c, currentRadioSelection));
+		currentRadioSelection = (Button)c;
 	}
 	
 	protected boolean isZippedPublisherAvailable() {
@@ -700,260 +720,7 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 		return (IDeployableServer) page.getServer().loadAdapter(
 				IDeployableServer.class, new NullProgressMonitor());
 	}
-/*
- * 
- * 
- * 
- * This is where the second half goes
- * 
- * 
- * 
- */
-	protected Composite createViewerPortion(Composite random) {
-		Composite root = new Composite(random, SWT.NONE);
-		root.setLayout(new FormLayout());
-
-		page.getFormToolkit(random).adapt(root);
-
-		viewer = new TreeViewer(root, SWT.BORDER);
-		viewer.getTree().setHeaderVisible(true);
-		viewer.getTree().setLinesVisible(true);
-		TreeColumn moduleColumn = new TreeColumn(viewer.getTree(), SWT.NONE);
-		TreeColumn publishLocColumn = new TreeColumn(viewer.getTree(), SWT.NONE);
-		TreeColumn publishTempLocColumn = new TreeColumn(viewer.getTree(),
-				SWT.NONE);
-		moduleColumn.setText(Messages.EditorModule);
-		publishLocColumn.setText(Messages.EditorSetDeployLabel);
-		publishTempLocColumn.setText(Messages.EditorSetTempDeployLabel);
-
-		moduleColumn.setWidth(200);
-		publishLocColumn.setWidth(200);
-		publishTempLocColumn.setWidth(200);
-
-		viewer.setContentProvider(new ModulePageContentProvider());
-
-		viewer.setLabelProvider(new ModulePageLabelProvider());
-		viewer.setColumnProperties(new String[] { COLUMN_NAME,
-				COLUMN_LOC, COLUMN_TEMP_LOC });
-		viewer.setInput("");  //$NON-NLS-1$
-		CellEditor[] editors = new CellEditor[] {
-				new TextCellEditor(viewer.getTree()),
-				new TextCellEditor(viewer.getTree()),
-				new TextCellEditor(viewer.getTree()) };
-		viewer.setCellModifier(new LocalDeploymentCellModifier());
-		viewer.setCellEditors(editors);
-		
-		Link link = new Link(root, SWT.DEFAULT);
-		link.setText("<a>" + Messages.EditorRefreshViewer + "</a>"); //$NON-NLS-1$ //$NON-NLS-2$
-		link.addSelectionListener(new SelectionListener() {
-			public void widgetSelected(SelectionEvent e) {
-				refreshViewer();
-			}
-			public void widgetDefaultSelected(SelectionEvent e) {
-			}
-		});
-		
-		FormData linkData = UIUtil.createFormData2(null, 0, 100,-10, 0,5,null,0);
-		link.setLayoutData(linkData);
-		
-		FormData treeData = UIUtil.createFormData2(0, 5, link,-5, 0,5,100,-5);
-		viewer.getTree().setLayoutData(treeData);
-
-		// Newer stuff
-		Label comboLabel = new Label(root, SWT.NULL);
-		comboLabel.setText("Filter by:");
-		filterCombo = new Combo(root, SWT.READ_ONLY);
-		filterCombo.setItems(new String[]{ALL, DEPLOYABLE, DEPLOYED, BY_MODNAME});
-		filterCombo.select(0);
-		
-		filterText = new Text(root, SWT.SINGLE |SWT.BORDER);
-		
-		comboLabel.setLayoutData(UIUtil.createFormData2(null,0,100,-8,link,5,null,0));
-		filterCombo.setLayoutData(UIUtil.createFormData2(null,0,100,-3,comboLabel,5,null,0));
-		filterText.setLayoutData(UIUtil.createFormData2(null,0,100,-3,filterCombo,5,100,-5));
-		
-		ModifyListener ml =new ModifyListener() {
-			public void modifyText(ModifyEvent e) {
-				resetFilterTextState();
-				viewer.setInput(""); //$NON-NLS-1$
-			}
-		};
-		filterCombo.addModifyListener(ml);
-		filterText.addModifyListener(ml);
-		filterCombo.select(1); // select DEPLOYABLE
-		return root;
-	}
 	
-	public void resetFilterTextState() {
-		int ind = filterCombo.getSelectionIndex();
-		boolean enabled = ind != -1 && 
-				filterCombo.getItem(ind).equals(BY_MODNAME);
-		filterText.setEnabled(enabled);
-	}
-	
-	private void refreshViewer() {
-		page.refreshPossibleModules();
-		viewer.setInput("");  //$NON-NLS-1$
-	}
-	
-	private class LocalDeploymentCellModifier implements ICellModifier {
-		public boolean canModify(Object element, String property) {
-			if( property == COLUMN_NAME)
-				return false;
-			return true;
-		}
-
-		public Object getValue(Object element, String property) {
-			DeploymentModulePrefs p = preferences.getOrCreatePreferences(MAIN)
-					.getOrCreateModulePrefs((IModule) element);
-			if (property == COLUMN_LOC) {
-				return getOutputFolderAndName(p, (IModule)element);
-			}
-			if (property == COLUMN_TEMP_LOC) {
-				String ret = p.getProperty(COLUMN_TEMP_LOC);
-				return ret == null ? "" : ret; //$NON-NLS-1$
-			}
-
-			return ""; //$NON-NLS-1$
-		}
-
-		public void modify(Object element, String property, Object value) {
-
-			IModule module = (IModule) ((TreeItem) element).getData();
-			DeploymentModulePrefs p = preferences.getOrCreatePreferences(MAIN)
-					.getOrCreateModulePrefs(module);
-			if (property == COLUMN_LOC) {
-				String outputName, outPath;
-				if( value == null || ((String)value).equals("")) { //$NON-NLS-1$
-					outputName = ""; //$NON-NLS-1$
-					outPath = ""; //$NON-NLS-1$
-				} else {
-					outputName = new Path(((String)value)).lastSegment();
-					outPath = ((String)value).substring(0, ((String)value).length()-outputName.length());
-				}
-				page.firePropertyChangeCommand(p, 
-						new String[]{COLUMN_LOC, OUTPUT_NAME},
-						new String[]{outPath,outputName},
-						Messages.EditorEditDeployLocCommand);
-				viewer.refresh();
-			} else if (property == COLUMN_TEMP_LOC) {
-				page.firePropertyChangeCommand(p, COLUMN_TEMP_LOC,
-						(String) value, Messages.EditorEditDeployLocCommand);
-				viewer.refresh();
-			}
-		}
-	}
-
-	private class ModulePageContentProvider implements ITreeContentProvider {
-		public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
-		}
-
-		public void dispose() {
-		}
-
-		public Object[] getElements(Object inputElement) {
-			return getFilteredModules();
-		}
-
-		public boolean hasChildren(Object element) {
-			return false;
-		}
-
-		public Object getParent(Object element) {
-			return null;
-		}
-
-		public Object[] getChildren(Object parentElement) {
-			return null;
-		}
-	}
-
-	private Object[] getFilteredModules(){
-		if( filterCombo == null )
-			return page.getPossibleModules();
-		if( filterCombo.getItem(filterCombo.getSelectionIndex()).equals(ALL))
-			return page.getPossibleModules();
-		if( filterCombo.getItem(filterCombo.getSelectionIndex()).equals(DEPLOYED))
-			return page.getServer().getModules();
-		else {
-			IModule[] mods = page.getPossibleModules();
-			ArrayList<IModule> result = new ArrayList<IModule>();
-			if( filterCombo.getItem(filterCombo.getSelectionIndex()).equals(DEPLOYABLE)) {
-				for( int i = 0; i < mods.length; i++) {
-					try {
-						IModule[] parent = page.getServer().getRootModules(mods[i], new NullProgressMonitor());
-						if( parent.length == 1 && parent[0] == mods[i]) {
-							result.add(mods[i]);
-						}
-					} catch(CoreException ce) {
-						// getRootModules only throws CE if modules cannot be modified.
-						// If they cannot be modified, they will not get added to result list.
-						// No logging is needed
-					}
-				}
-			}
-			if( filterCombo.getItem(filterCombo.getSelectionIndex()).equals(BY_MODNAME)) {
-				String txt = filterText.getText();
-				for( int i = 0; i < mods.length; i++) {
-					if( mods[i].getName().contains(txt)) {
-						result.add(mods[i]);
-					}
-				}
-			}
-			return result.toArray(new IModule[result.size()]);
-		}
-	}
-	
-	private class ModulePageLabelProvider implements ITableLabelProvider {
-		public Image getColumnImage(Object element, int columnIndex) {
-			if (element instanceof IModule && columnIndex == 0) {
-				ILabelProvider labelProvider = ServerUICore.getLabelProvider();
-				Image image = labelProvider.getImage((IModule) element);
-				labelProvider.dispose();
-				return image;
-			}
-			return null;
-		}
-
-		public String getColumnText(Object element, int columnIndex) {
-			if (element instanceof IModule) {
-				IModule m = (IModule) element;
-				if (columnIndex == 0)
-					return m.getName();
-				if (columnIndex == 1) {
-					DeploymentModulePrefs modPref = preferences
-							.getOrCreatePreferences(MAIN)
-							.getOrCreateModulePrefs(m);
-					return getOutputFolderAndName(modPref, m);
-				}
-				if (columnIndex == 2) {
-					DeploymentModulePrefs modPref = preferences
-							.getOrCreatePreferences(MAIN)
-							.getOrCreateModulePrefs(m);
-					String result = modPref.getProperty(COLUMN_TEMP_LOC);
-					if (result != null)
-						return result;
-					modPref.setProperty(COLUMN_TEMP_LOC, ""); //$NON-NLS-1$
-					return ""; //$NON-NLS-1$
-				}
-			}
-			return element.toString();
-		}
-
-		public void addListener(ILabelProviderListener listener) {
-		}
-
-		public void dispose() {
-		}
-
-		public boolean isLabelProperty(Object element, String property) {
-			return false;
-		}
-
-		public void removeListener(ILabelProviderListener listener) {
-		}
-	}
-
 	public void updateListeners() {
 		// server has been saved. Remove property change listener from last wc and add to newest
 		if( lastWC != null )
@@ -968,7 +735,7 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 			if( shouldCreateMetadataRadio() ) {
 				metadataRadio.setEnabled(shouldEnableMetadataRadio());
 				if(!metadataRadio.isEnabled() && metadataRadio.getSelection()) {
-					page.execute(new RadioClickedCommand(serverRadio, currentSelection));
+					page.execute(new RadioClickedCommand(serverRadio, currentRadioSelection));
 				}
 			}
 		} 
@@ -984,27 +751,28 @@ public class DeploymentModuleOptionCompositeAssistant implements PropertyChangeL
 		return  ret;
 	}
 	
-	protected static String getOutputFolderAndName(DeploymentModulePrefs modPref, IModule m) {
-		String folder = modPref.getProperty(COLUMN_LOC);
-		String outputName = modPref.getProperty(OUTPUT_NAME);
-		outputName = outputName == null || outputName.length() == 0
-			? getDefaultOutputName(m) : outputName;
-			
-		if (folder != null)
-			return new Path(folder).append(outputName).toPortableString();
-		return outputName;
-	}
-
 	public void setEnabled(boolean enabled) {
-		Control[] c = new Control[] { 
-				viewer.getTree(), deployText, tempDeployText, 
-				metadataRadio, serverRadio, customRadio, currentSelection, 
-				deployButton, tempDeployButton
-		};
-		for( int i = 0; i < c.length; i++ ) {
-			if( shouldEnableControl(c[i])) {
-				c[i].setEnabled(enabled);
+		Iterator<Control> i = enableDisableWidgets.iterator();
+		while(i.hasNext()) {
+			Control c = i.next();
+			if( shouldEnableControl(c)) {
+				c.setEnabled(enabled);
 			}
 		}
 	}
+	
+	/*
+	 * This method may be overridden with specific logic for your list of radios
+	 */
+	protected boolean shouldEnableControl(Control c) {
+		if( c == null || c.isDisposed())
+			return false;
+		
+		if( c == deployText || c == tempDeployText || c == deployButton || c == tempDeployButton)
+			return getDeployType().equals(IDeployableServer.DEPLOY_CUSTOM);
+		if( c == metadataRadio)
+			return shouldEnableMetadataRadio();
+		return true;
+	}
+
 }

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/editor/ModuleDeploymentOptionsComposite.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/editor/ModuleDeploymentOptionsComposite.java
@@ -1,0 +1,447 @@
+/******************************************************************************* 
+* Copyright (c) 2011-2013 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.ide.eclipse.as.ui.editor;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jface.viewers.CellEditor;
+import org.eclipse.jface.viewers.ICellModifier;
+import org.eclipse.jface.viewers.ILabelProvider;
+import org.eclipse.jface.viewers.ILabelProviderListener;
+import org.eclipse.jface.viewers.ITableLabelProvider;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.TextCellEditor;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.FormData;
+import org.eclipse.swt.layout.FormLayout;
+import org.eclipse.swt.widgets.Combo;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.swt.widgets.TreeColumn;
+import org.eclipse.swt.widgets.TreeItem;
+import org.eclipse.ui.forms.widgets.FormToolkit;
+import org.eclipse.wst.server.core.IModule;
+import org.eclipse.wst.server.core.IServerWorkingCopy;
+import org.eclipse.wst.server.ui.ServerUICore;
+import org.jboss.ide.eclipse.as.core.publishers.LocalPublishMethod;
+import org.jboss.ide.eclipse.as.core.publishers.PublishUtil;
+import org.jboss.ide.eclipse.as.core.util.DeploymentPreferenceLoader.DeploymentModulePrefs;
+import org.jboss.ide.eclipse.as.core.util.DeploymentPreferenceLoader.DeploymentPreferences;
+import org.jboss.ide.eclipse.as.core.util.IJBossToolingConstants;
+import org.jboss.ide.eclipse.as.ui.Messages;
+import org.jboss.ide.eclipse.as.ui.UIUtil;
+
+public class ModuleDeploymentOptionsComposite extends Composite implements PropertyChangeListener {
+	protected static final String ALL = Messages.EditorDeploymentPageFilterAll;
+	protected static final String DEPLOYABLE = Messages.EditorDeploymentPageFilterDeployable;
+	protected static final String DEPLOYED = Messages.EditorDeploymentPageFilterDeployed;
+	protected static final String BY_MODNAME = Messages.EditorDeploymentPageFilterModuleName;
+	
+	
+	protected static final String COLUMN_NAME = IJBossToolingConstants.LOCAL_DEPLOYMENT_NAME;
+	protected static final String COLUMN_LOC = IJBossToolingConstants.LOCAL_DEPLOYMENT_LOC;
+	protected static final String COLUMN_TEMP_LOC = IJBossToolingConstants.LOCAL_DEPLOYMENT_TEMP_LOC;
+	protected static final String OUTPUT_NAME = IJBossToolingConstants.LOCAL_DEPLOYMENT_OUTPUT_NAME;
+	protected static final String MAIN = LocalPublishMethod.LOCAL_PUBLISH_METHOD;
+	
+	private DeploymentPreferences preferences;
+	private TreeViewer viewer;
+	private Combo filterCombo; 
+	private Text filterText;
+	private IModuleDeploymentOptionsPartner partner;
+	
+	private IServerWorkingCopy lastWC;
+	protected ArrayList<IModule> possibleModules;
+	private FormToolkit tk;
+	
+	/**
+	 * @noimplement This interface is not intended to be implemented by clients.
+	 *
+	 */
+	public static interface IModuleDeploymentOptionsPartner {
+		/**
+		 * Get the current working copy of a server
+		 * @return
+		 */
+		public IServerWorkingCopy getServer();
+		
+		/**
+		 * Save the deployment attribute changes to the working copy. 
+		 * The typical implementation of this method does it via an editor command
+		 * so that it can be undone. If this composite is instantiated in 
+		 * any other place, a proper IModuleDeploymentOptionsPartner will just persist them in the working copy directly
+		 * @param p
+		 * @param keys
+		 * @param vals
+		 * @param cmdName
+		 */
+		public void firePropertyChangeCommand(DeploymentModulePrefs p, String[] keys, String[] vals, String cmdName);
+	}
+	
+	public ModuleDeploymentOptionsComposite(Composite parent, IModuleDeploymentOptionsPartner partner, FormToolkit tk, DeploymentPreferences prefs) {
+		super(parent, SWT.NONE);
+		this.partner = partner;
+		this.preferences = prefs;
+		lastWC = partner.getServer();
+		lastWC.addPropertyChangeListener(this);
+		this.tk = tk;
+		refreshPossibleModules();
+		createViewerPortion(this);
+	}
+
+	public void dispose() {
+		lastWC.removePropertyChangeListener(this);
+	}
+	
+	/* Subclasses should override */
+	private void updateWidgets() {
+	}
+	
+	/*
+	 * This part adds the viewer for customizing on a per-module basis 
+	 */
+	protected Composite createViewerPortion(Composite root) {
+		setLayout(new FormLayout());
+
+		tk.adapt(root);
+
+		viewer = new TreeViewer(root, SWT.BORDER);
+		viewer.getTree().setHeaderVisible(true);
+		viewer.getTree().setLinesVisible(true);
+		TreeColumn moduleColumn = new TreeColumn(viewer.getTree(), SWT.NONE);
+		TreeColumn publishLocColumn = new TreeColumn(viewer.getTree(), SWT.NONE);
+		TreeColumn publishTempLocColumn = new TreeColumn(viewer.getTree(),
+				SWT.NONE);
+		moduleColumn.setText(Messages.EditorModule);
+		publishLocColumn.setText(Messages.EditorSetDeployLabel);
+		publishTempLocColumn.setText(Messages.EditorSetTempDeployLabel);
+
+		moduleColumn.setWidth(200);
+		publishLocColumn.setWidth(200);
+		publishTempLocColumn.setWidth(200);
+
+		viewer.setContentProvider(new ModulePageContentProvider());
+
+		viewer.setLabelProvider(new ModulePageLabelProvider());
+		viewer.setColumnProperties(new String[] { COLUMN_NAME,
+				COLUMN_LOC, COLUMN_TEMP_LOC });
+		viewer.setInput("");  //$NON-NLS-1$
+		CellEditor[] editors = new CellEditor[] {
+				new TextCellEditor(viewer.getTree()),
+				new TextCellEditor(viewer.getTree()),
+				new TextCellEditor(viewer.getTree()) };
+		viewer.setCellModifier(new LocalDeploymentCellModifier());
+		viewer.setCellEditors(editors);
+		
+		Link link = new Link(root, SWT.DEFAULT);
+		link.setText("<a>" + Messages.EditorRefreshViewer + "</a>"); //$NON-NLS-1$ //$NON-NLS-2$
+		link.addSelectionListener(new SelectionListener() {
+			public void widgetSelected(SelectionEvent e) {
+				refreshViewer();
+			}
+			public void widgetDefaultSelected(SelectionEvent e) {
+			}
+		});
+		
+		FormData linkData = UIUtil.createFormData2(null, 0, 100,-10, 0,5,null,0);
+		link.setLayoutData(linkData);
+		
+		FormData treeData = UIUtil.createFormData2(0, 5, link,-5, 0,5,100,-5);
+		viewer.getTree().setLayoutData(treeData);
+
+		// Newer stuff
+		Label comboLabel = new Label(root, SWT.NULL);
+		comboLabel.setText(Messages.EditorDeploymentPageFilterBy);
+		filterCombo = new Combo(root, SWT.READ_ONLY);
+		filterCombo.setItems(getViewerFilterTypes());
+		filterCombo.select(0);
+		
+		filterText = new Text(root, SWT.SINGLE |SWT.BORDER);
+		
+		comboLabel.setLayoutData(UIUtil.createFormData2(null,0,100,-8,link,5,null,0));
+		filterCombo.setLayoutData(UIUtil.createFormData2(null,0,100,-3,comboLabel,5,null,0));
+		filterText.setLayoutData(UIUtil.createFormData2(null,0,100,-3,filterCombo,5,100,-5));
+		
+		ModifyListener ml =new ModifyListener() {
+			public void modifyText(ModifyEvent e) {
+				resetFilterTextState();
+				viewer.setInput(""); //$NON-NLS-1$
+			}
+		};
+		filterCombo.addModifyListener(ml);
+		filterText.addModifyListener(ml);
+		filterCombo.select(1); // select DEPLOYABLE
+		return root;
+	}
+	
+	/*
+	 * Extenders can override this to provide additional filter types
+	 */
+	protected String[] getViewerFilterTypes() {
+		return new String[]{ALL, DEPLOYABLE, DEPLOYED, BY_MODNAME};
+	}
+	
+	public void resetFilterTextState() {
+		int ind = filterCombo.getSelectionIndex();
+		boolean enabled = ind != -1 && usesViewerFilterText(filterCombo.getItem(ind));
+		filterText.setEnabled(enabled);
+	}
+	
+	/*
+	 * Subclasses with custom filter types may override this method.
+	 * Any filter mechanism which makes use of the text field should return true here
+	 */
+	protected boolean usesViewerFilterText(String comboItem) {
+		return BY_MODNAME.equals(comboItem);
+	}
+	
+	private void refreshViewer() {
+		refreshPossibleModules();
+		viewer.setInput("");  //$NON-NLS-1$
+	}
+	
+	/*
+	 * Reload the list of possible modules from the most recent working copy of the server
+	 */
+	protected void refreshPossibleModules() {
+		ArrayList<IModule> possibleChildren = new ArrayList<IModule>();
+		IModule[] modules2 = org.eclipse.wst.server.core.ServerUtil.getModules(partner.getServer().getServerType().getRuntimeType().getModuleTypes());
+		if (modules2 != null) {
+			int size = modules2.length;
+			for (int i = 0; i < size; i++) {
+				IModule module = modules2[i];
+				IStatus status = partner.getServer().canModifyModules(new IModule[] { module }, null, null);
+				if (status != null && status.getSeverity() != IStatus.ERROR)
+					possibleChildren.add(module);
+			}
+		}
+		this.possibleModules = possibleChildren;
+	}
+	
+
+	public IModule[] getPossibleModules() {
+		return (IModule[]) possibleModules.toArray(new IModule[possibleModules.size()]);
+	}
+	
+	
+	
+	private class LocalDeploymentCellModifier implements ICellModifier {
+		public boolean canModify(Object element, String property) {
+			if( property == COLUMN_NAME)
+				return false;
+			return true;
+		}
+
+		public Object getValue(Object element, String property) {
+			DeploymentModulePrefs p = preferences.getOrCreatePreferences(MAIN)
+					.getOrCreateModulePrefs((IModule) element);
+			if (property == COLUMN_LOC) {
+				return getOutputFolderAndName(p, (IModule)element);
+			}
+			if (property == COLUMN_TEMP_LOC) {
+				String ret = p.getProperty(COLUMN_TEMP_LOC);
+				return ret == null ? "" : ret; //$NON-NLS-1$
+			}
+
+			return ""; //$NON-NLS-1$
+		}
+
+		public void modify(Object element, String property, Object value) {
+
+			IModule module = (IModule) ((TreeItem) element).getData();
+			DeploymentModulePrefs p = preferences.getOrCreatePreferences(MAIN)
+					.getOrCreateModulePrefs(module);
+			if (property == COLUMN_LOC) {
+				String outputName, outPath;
+				if( value == null || ((String)value).equals("")) { //$NON-NLS-1$
+					outputName = ""; //$NON-NLS-1$
+					outPath = ""; //$NON-NLS-1$
+				} else {
+					outputName = new Path(((String)value)).lastSegment();
+					outPath = ((String)value).substring(0, ((String)value).length()-outputName.length());
+				}
+				partner.firePropertyChangeCommand(p, 
+						new String[]{COLUMN_LOC, OUTPUT_NAME},
+						new String[]{outPath,outputName},
+						Messages.EditorEditDeployLocCommand);
+				viewer.refresh();
+			} else if (property == COLUMN_TEMP_LOC) {
+				partner.firePropertyChangeCommand(p, 
+						new String[] { COLUMN_TEMP_LOC },
+						new String[] {(String) value}, 
+						Messages.EditorEditDeployLocCommand);
+				viewer.refresh();
+			}
+		}
+	}
+
+	private class ModulePageContentProvider implements ITreeContentProvider {
+		public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+		}
+
+		public void dispose() {
+		}
+
+		public Object[] getElements(Object inputElement) {
+			return getFilteredModules();
+		}
+
+		public boolean hasChildren(Object element) {
+			return false;
+		}
+
+		public Object getParent(Object element) {
+			return null;
+		}
+
+		public Object[] getChildren(Object parentElement) {
+			return null;
+		}
+	}
+
+	/*
+	 * Subclasses with a custom filter type may override this method
+	 * This returns an array of objects which survive the filter. 
+	 */
+	protected Object[] getFilteredModules(){
+		IModule[] mods = getPossibleModules();
+		if( filterCombo == null )
+			return mods;
+		if( filterCombo.getItem(filterCombo.getSelectionIndex()).equals(ALL))
+			return mods;
+		if( filterCombo.getItem(filterCombo.getSelectionIndex()).equals(DEPLOYED))
+			return partner.getServer().getModules();
+		else {
+			ArrayList<IModule> result = new ArrayList<IModule>();
+			if( filterCombo.getItem(filterCombo.getSelectionIndex()).equals(DEPLOYABLE)) {
+				for( int i = 0; i < mods.length; i++) {
+					try {
+						IModule[] parent = partner.getServer().getRootModules(mods[i], new NullProgressMonitor());
+						if( parent.length == 1 && parent[0] == mods[i]) {
+							result.add(mods[i]);
+						}
+					} catch(CoreException ce) {
+						// getRootModules only throws CE if modules cannot be modified.
+						// If they cannot be modified, they will not get added to result list.
+						// No logging is needed
+					}
+				}
+			}
+			if( filterCombo.getItem(filterCombo.getSelectionIndex()).equals(BY_MODNAME)) {
+				String txt = filterText.getText();
+				for( int i = 0; i < mods.length; i++) {
+					if( mods[i].getName().contains(txt)) {
+						result.add(mods[i]);
+					}
+				}
+			}
+			return result.toArray(new IModule[result.size()]);
+		}
+	}
+	
+	private class ModulePageLabelProvider implements ITableLabelProvider {
+		public Image getColumnImage(Object element, int columnIndex) {
+			if (element instanceof IModule && columnIndex == 0) {
+				ILabelProvider labelProvider = ServerUICore.getLabelProvider();
+				Image image = labelProvider.getImage((IModule) element);
+				labelProvider.dispose();
+				return image;
+			}
+			return null;
+		}
+
+		public String getColumnText(Object element, int columnIndex) {
+			if (element instanceof IModule) {
+				IModule m = (IModule) element;
+				if (columnIndex == 0)
+					return m.getName();
+				if (columnIndex == 1) {
+					DeploymentModulePrefs modPref = preferences
+							.getOrCreatePreferences(MAIN)
+							.getOrCreateModulePrefs(m);
+					return getOutputFolderAndName(modPref, m);
+				}
+				if (columnIndex == 2) {
+					DeploymentModulePrefs modPref = preferences
+							.getOrCreatePreferences(MAIN)
+							.getOrCreateModulePrefs(m);
+					String result = modPref.getProperty(COLUMN_TEMP_LOC);
+					if (result != null)
+						return result;
+					modPref.setProperty(COLUMN_TEMP_LOC, ""); //$NON-NLS-1$
+					return ""; //$NON-NLS-1$
+				}
+			}
+			return element.toString();
+		}
+
+		public void addListener(ILabelProviderListener listener) {
+		}
+
+		public void dispose() {
+		}
+
+		public boolean isLabelProperty(Object element, String property) {
+			return false;
+		}
+
+		public void removeListener(ILabelProviderListener listener) {
+		}
+	}
+
+	public void updateListeners() {
+		// server has been saved. Remove property change listener from last wc and add to newest
+		if( lastWC != null )
+			lastWC.removePropertyChangeListener(this);
+		lastWC = partner.getServer();
+		if( lastWC != null )
+			lastWC.addPropertyChangeListener(this);
+	}
+
+	/* Subclasses can override */
+	public void propertyChange(PropertyChangeEvent evt) {
+		updateWidgets();
+	}
+	
+	
+	private String getDefaultOutputName(IModule module) {
+		String lastSegment = new Path(module.getName()).lastSegment();
+		String suffix = PublishUtil.getSuffix(module.getModuleType().getId());
+		String ret = lastSegment.endsWith(suffix) ? lastSegment : lastSegment + suffix;
+		return  ret;
+	}
+	
+	private String getOutputFolderAndName(DeploymentModulePrefs modPref, IModule m) {
+		String folder = modPref.getProperty(COLUMN_LOC);
+		String outputName = modPref.getProperty(OUTPUT_NAME);
+		outputName = outputName == null || outputName.length() == 0
+			? getDefaultOutputName(m) : outputName;
+			
+		if (folder != null)
+			return new Path(folder).append(outputName).toPortableString();
+		return outputName;
+	}
+}


### PR DESCRIPTION
...for customizing deployment names

The server editor's deployments page consists of 3 moving parts:
  1)  the 'page' itself
  2) a "composite assistant" to make the various controls (deloy folder, tmp deploy folder, deploymenttype:server/metadata/custom)
  3) the same composite assistant to make the viewer for customizing modules' deploy names

The assistant was basically a poorly-made internal utility class and it was not a composite on its own. The workflow was poor and hard to follow.  This patch splits it up now into:
  1) The page
  2) the "composite assistant" to make the top-level items  (deloy folder, tmp deploy folder, deploymenttype:server/metadata/custom)
  3) A new actual composite to show the viewer

Unfortunately the composite assistant could not be changed to a composite immediately because it still uses a hack interface (which is used by rse.ui) for gathering the remote server home, configuration, etc. Until those APIs are cleaned up, this will have to suffice as a first pass.  Cleaning up those interfaces are a clear issue that is already prioritized very highly (because enabling remote deployment scanners needs it), but it is not part of this specific jira. Since the hack interface is in .ui classes, but its replacement will be in .core, it would be impossible to fix the interface issue first. 
