### PR TITLE
JBIDE-10219 Migrate org.eclipse.core.runtime.contentTypes

### DIFF
--- a/archives/plugins/org.jboss.ide.eclipse.archives.core/plugin.xml
+++ b/archives/plugins/org.jboss.ide.eclipse.archives.core/plugin.xml
@@ -32,7 +32,7 @@
 
 	<!-- LEGACY - JBIDE-1041 -->
    <extension
-         point="org.eclipse.core.runtime.contentTypes">
+         point="org.eclipse.core.contenttype.contentTypes">
       <file-association
             file-names="packaging-build.xml"
             content-type="org.eclipse.ant.core.antBuildFile">

--- a/as/plugins/org.jboss.ide.eclipse.as.ui.mbeans/plugin.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui.mbeans/plugin.xml
@@ -4,7 +4,7 @@
    <extension-point id="ServiceXMLQuickFixProvider" name="org.jboss.ide.eclipse.as.ui.mbeans.serviceXMLQuickFixProvider" schema="schema/ServiceXMLQuickFixProvider.exsd"/>
    <extension-point id="ServiceXMLOutlineMenuProvider" name="org.jboss.ide.eclipse.as.ui.mbeans.serviceXMLOutlineMenuProvider" schema="schema/ServiceXMLOutlineMenuProvider.exsd"/>
    <extension
-         point="org.eclipse.core.runtime.contentTypes">
+         point="org.eclipse.core.contenttype.contentTypes">
       <content-type
             base-type="org.eclipse.core.runtime.xml"
             file-extensions="xml"


### PR DESCRIPTION
Migrate org.eclipse.core.runtime.contentTypes extension points to org.eclipse.core.contenttype.contentTypes
