### PR TITLE
JBIDE-15392

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.classpath.core/src/org/jboss/ide/eclipse/as/classpath/core/runtime/RuntimeJarUtility.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.classpath.core/src/org/jboss/ide/eclipse/as/classpath/core/runtime/RuntimeJarUtility.java
@@ -1,0 +1,187 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.ide.eclipse.as.classpath.core.runtime;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.wst.server.core.IRuntime;
+import org.eclipse.wst.server.core.IRuntimeType;
+import org.eclipse.wst.server.core.IServerType;
+import org.eclipse.wst.server.core.ServerCore;
+import org.jboss.ide.eclipse.as.classpath.core.runtime.internal.DefaultClasspathJarLocator;
+import org.jboss.ide.eclipse.as.classpath.core.runtime.internal.SourceJarsLocator;
+import org.jboss.ide.eclipse.as.core.resolvers.ConfigNameResolver;
+import org.jboss.ide.eclipse.as.core.server.bean.ServerBeanLoader;
+import org.jboss.ide.eclipse.as.core.server.internal.extendedproperties.ServerExtendedProperties;
+import org.jboss.ide.eclipse.as.core.server.internal.v7.LocalJBoss7ServerRuntime;
+import org.jboss.ide.eclipse.as.core.util.IJBossRuntimeResourceConstants;
+
+/**
+ * This class assists in fetching a set of jars based on a given
+ * criteria for a relevant runtime
+ * 
+ * @since 2.5
+ */
+public class RuntimeJarUtility {
+	/**
+	 * A key representing only jars which should be on a project classpath
+	 */
+	public static final int CLASSPATH_JARS = 1;
+	
+	/**
+	 * A key representing ALL jars for the appropriate 
+	 * current configuration of the runtime only.
+	 * (ie default, all, minimal, standalone, etc)
+	 */
+	public static final int ALL_JARS = 2;
+	
+	/**
+	 * This constant for string substitution which represents a configuration directory 
+	 * This constant is the variable form of the constant.  ${varname}
+	 */
+	public static final String CONFIG_DIR_VAR_PATTERN = ConfigNameResolver.getVariablePattern(ConfigNameResolver.JBOSS_CONFIG_DIR); 
+
+	/**
+	 * This constant for string substitution which represents a server's home directory 
+	 * This constant is the variable form of the constant.  ${varname}
+	 */
+	public static final String SERVER_HOME_VAR_PATTERN = ConfigNameResolver.getVariablePattern(ConfigNameResolver.JBOSS_SERVER_HOME);
+
+
+	
+	/**
+	 * Return a list of jars for the given request type and runtime,
+	 * or, return null if the request type is unknown for the given runtime. 
+	 *  
+	 * @param rt  A runtime 
+	 * @param type  The type of request for jars being made
+	 * @return
+	 */
+	public IPath[] getJarsForRuntime(IRuntime rt, int type) {
+		if( type == CLASSPATH_JARS) {
+			IRuntimePathProvider[] sets = CustomRuntimeClasspathModel.getInstance().getEntries(rt.getRuntimeType());
+			IPath[] allPaths = DefaultClasspathJarLocator.getAllEntries(rt, sets);
+			return allPaths;
+		} else if( type == ALL_JARS) {
+			IRuntimePathProvider[] sets = new SourceJarsLocator().getDefaultPathProviders(rt.getRuntimeType());
+			IPath[] allPaths = DefaultClasspathJarLocator.getAllEntries(rt, sets);
+			return allPaths;
+		}
+		return null;
+	}
+	
+	/**
+	 * Return a list of jars for the given request type and runtime,
+	 * or, return null if the request type is unknown for the given runtime. 
+	 *  
+	 * @param rt  A runtime 
+	 * @param type  The type of request for jars being made
+	 * @return
+	 */
+	public IPath[] getJarsForRuntimeHome(String home, int type) {
+		return getJarsForRuntimeHome(home, type, true);
+	}
+	
+	
+	/**
+ 	 * Return a list of jars for the given request type and runtime,
+	 * or, return null if the request type is unknown for the given runtime,
+	 * or if the given home directory represents an unknown server type.  
+	 * 
+	 * @param home  The server home
+	 * @param type  The type of request being made
+	 * @param setDefaults Whether to add unset default string replacements, like jboss_config_name
+	 * @return
+	 */
+	public IPath[] getJarsForRuntimeHome(String home, int type, boolean setDefaults) {
+		HashMap<String, String> map = new HashMap<String, String>();
+		return getJarsForRuntimeHome(home, type, map, setDefaults);
+	}
+	
+	/**
+ 	 * Return a list of jars for the given request type and runtime,
+	 * or, return null if the request type is unknown for the given runtime,
+	 * or if the given home directory represents an unknown server type.  
+	 * 
+	 * @param home  The server home
+	 * @param type  The type of request being made
+	 * @param replacements  A map of string replacements
+	 * @param setDefaults Whether to add unset default string replacements, like jboss_config_name
+	 * @return
+	 */
+	public IPath[] getJarsForRuntimeHome(String home, int type, Map<String, String> replacements, boolean setDefaultReplacements) {
+		// Force the server home to be accurate
+		replacements.put(ConfigNameResolver.JBOSS_SERVER_HOME, home);
+
+		ServerBeanLoader loader = new ServerBeanLoader(new File(home));
+		String serverType = loader.getServerAdapterId();
+		IServerType t = serverType == null ? null : ServerCore.findServerType(serverType);
+		IRuntimeType rtType = t == null ? null : t.getRuntimeType();
+		if( rtType == null ) {
+			return null;
+		}
+		
+		if( setDefaultReplacements ) {
+			setDefaultReplacements(t, home, replacements);
+		}
+		
+		if( type == CLASSPATH_JARS) {
+			IRuntimePathProvider[] sets = CustomRuntimeClasspathModel.getInstance().getEntries(rtType);
+			IPath[] allPaths = DefaultClasspathJarLocator.getAllEntries(replacements, sets);
+			return allPaths;
+		} else if( type == ALL_JARS) {
+			IRuntimePathProvider[] sets = new SourceJarsLocator().getDefaultPathProviders(rtType);
+			IPath[] allPaths = DefaultClasspathJarLocator.getAllEntries(replacements, sets);
+			return allPaths;
+		}
+		return null;
+	}
+
+	/**
+	 * Add default replacements in the same way a runtime object with the property value empty would behave. 
+	 * 
+	 * @param type
+	 * @param home
+	 * @param replacements
+	 */
+	private void setDefaultReplacements(IServerType type, String home, Map<String, String> replacements) {
+		ServerExtendedProperties props = (ServerExtendedProperties)Platform.getAdapterManager().getAdapter(type,ServerExtendedProperties.class);
+		if( props != null ) {
+			int fileStructure = props.getFileStructure();
+			IPath serverHome = new Path(home);
+			if( fileStructure == ServerExtendedProperties.FILE_STRUCTURE_SERVER_CONFIG_DEPLOY) {
+				if( replacements.get(ConfigNameResolver.JBOSS_CONFIG) == null ) {
+					replacements.put(ConfigNameResolver.JBOSS_CONFIG, IJBossRuntimeResourceConstants.DEFAULT_CONFIGURATION);
+				}
+				String cfg = replacements.get(ConfigNameResolver.JBOSS_CONFIG);
+				if( replacements.get(ConfigNameResolver.JBOSS_CONFIG_DIR) == null ) {
+					replacements.put(ConfigNameResolver.JBOSS_CONFIG_DIR, serverHome.append(IJBossRuntimeResourceConstants.SERVER).append(cfg).toOSString());
+				}
+			}
+			
+			if( fileStructure == ServerExtendedProperties.FILE_STRUCTURE_SERVER_CONFIG_DEPLOY) {
+				if( replacements.get(ConfigNameResolver.JBOSS_AS7_CONFIG_FILE) == null ) {
+					replacements.put(ConfigNameResolver.JBOSS_AS7_CONFIG_FILE, LocalJBoss7ServerRuntime.CONFIG_FILE_DEFAULT);
+				}
+				if( replacements.get(ConfigNameResolver.JBOSS_CONFIG_DIR) == null ) {
+					replacements.put(ConfigNameResolver.JBOSS_CONFIG_DIR, serverHome.append(IJBossRuntimeResourceConstants.AS7_STANDALONE)
+							.append(IJBossRuntimeResourceConstants.CONFIGURATION).toOSString());
+				}
+			}
+			
+		}
+	}
+}

--- a/as/plugins/org.jboss.ide.eclipse.as.classpath.core/src/org/jboss/ide/eclipse/as/classpath/core/runtime/internal/ClientAllRuntimeClasspathProvider.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.classpath.core/src/org/jboss/ide/eclipse/as/classpath/core/runtime/internal/ClientAllRuntimeClasspathProvider.java
@@ -28,8 +28,7 @@ import org.eclipse.jst.server.core.RuntimeClasspathProviderDelegate;
 import org.eclipse.wst.server.core.IRuntime;
 import org.jboss.ide.eclipse.as.classpath.core.ClasspathCorePlugin;
 import org.jboss.ide.eclipse.as.classpath.core.internal.Messages;
-import org.jboss.ide.eclipse.as.classpath.core.runtime.CustomRuntimeClasspathModel;
-import org.jboss.ide.eclipse.as.classpath.core.runtime.IRuntimePathProvider;
+import org.jboss.ide.eclipse.as.classpath.core.runtime.RuntimeJarUtility;
 
 /**
  * This class uses the "throw everything you can find" strategy
@@ -124,8 +123,7 @@ public class ClientAllRuntimeClasspathProvider
 	}
 	
 	protected IClasspathEntry[] getClasspathEntriesForRuntime(IRuntime rt) {
-		IRuntimePathProvider[] sets = CustomRuntimeClasspathModel.getInstance().getEntries(rt.getRuntimeType());
-		IPath[] allPaths = DefaultClasspathJarLocator.getAllEntries(rt, sets);
+		IPath[] allPaths = new RuntimeJarUtility().getJarsForRuntime(rt, RuntimeJarUtility.CLASSPATH_JARS);
 		ArrayList<Entry> entries = new ArrayList<Entry>();
 		for( int i = 0; i < allPaths.length; i++ ) {
 			addSinglePath(allPaths[i], entries);

--- a/as/plugins/org.jboss.ide.eclipse.as.classpath.core/src/org/jboss/ide/eclipse/as/classpath/core/runtime/internal/DefaultClasspathJarLocator.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.classpath.core/src/org/jboss/ide/eclipse/as/classpath/core/runtime/internal/DefaultClasspathJarLocator.java
@@ -18,8 +18,8 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.wst.server.core.IRuntime;
 import org.eclipse.wst.server.core.IRuntimeType;
 import org.jboss.ide.eclipse.as.classpath.core.runtime.IRuntimePathProvider;
+import org.jboss.ide.eclipse.as.classpath.core.runtime.RuntimeJarUtility;
 import org.jboss.ide.eclipse.as.classpath.core.runtime.RuntimePathProviderFileset;
-import org.jboss.ide.eclipse.as.core.resolvers.ConfigNameResolver;
 import org.jboss.ide.eclipse.as.core.resolvers.RuntimeVariableResolver;
 import org.jboss.ide.eclipse.as.core.util.IJBossRuntimeResourceConstants;
 import org.jboss.ide.eclipse.as.core.util.IJBossToolingConstants;
@@ -33,7 +33,7 @@ import org.jboss.tools.foundation.core.expressions.IVariableResolver;
 public class DefaultClasspathJarLocator implements IJBossToolingConstants, IJBossRuntimeResourceConstants {
 	private static final String SEP = "/"; //$NON-NLS-1$
 	private static final String EMPTY = ""; //$NON-NLS-1$
-	private static final String CONFIG_DIR = ConfigNameResolver.getVariablePattern(ConfigNameResolver.JBOSS_CONFIG_DIR);
+	private static final String CONFIG_DIR = RuntimeJarUtility.CONFIG_DIR_VAR_PATTERN;
 	
 	public IRuntimePathProvider[] getDefaultPathProviders(IRuntimeType type) {
 		String rtID = type.getId();

--- a/as/plugins/org.jboss.ide.eclipse.as.classpath.core/src/org/jboss/ide/eclipse/as/classpath/core/runtime/internal/SourceJarsLocator.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.classpath.core/src/org/jboss/ide/eclipse/as/classpath/core/runtime/internal/SourceJarsLocator.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2011-2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.ide.eclipse.as.classpath.core.runtime.internal;
+
+import java.util.ArrayList;
+
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.wst.server.core.IRuntimeType;
+import org.jboss.ide.eclipse.as.classpath.core.runtime.IRuntimePathProvider;
+import org.jboss.ide.eclipse.as.classpath.core.runtime.RuntimeJarUtility;
+import org.jboss.ide.eclipse.as.classpath.core.runtime.RuntimePathProviderFileset;
+import org.jboss.ide.eclipse.as.core.server.internal.extendedproperties.ServerExtendedProperties;
+import org.jboss.ide.eclipse.as.core.util.IJBossRuntimeResourceConstants;
+import org.jboss.ide.eclipse.as.core.util.IJBossToolingConstants;
+
+/**
+ * Find ALL jars for a relevant configuration of a server
+ */
+public class SourceJarsLocator implements IJBossToolingConstants, IJBossRuntimeResourceConstants {
+	private static final String SEP = "/"; //$NON-NLS-1$
+	private static final String CONFIG_DIR = RuntimeJarUtility.CONFIG_DIR_VAR_PATTERN;
+
+	public IRuntimePathProvider[] getDefaultPathProviders(IRuntimeType rt) {
+		ServerExtendedProperties props = (ServerExtendedProperties) Platform.getAdapterManager().getAdapter(
+				rt, ServerExtendedProperties.class);
+		IRuntimePathProvider[] providers = new IRuntimePathProvider[]{};
+		if( props != null ) {
+			int structure = props.getFileStructure();
+			if( structure == ServerExtendedProperties.FILE_STRUCTURE_SERVER_CONFIG_DEPLOY) {
+				providers = serverConfigDeployJars(rt);
+			} else if( structure == ServerExtendedProperties.FILE_STRUCTURE_CONFIG_DEPLOYMENTS ) { 
+				providers = configDeploymentsJars(rt);
+			}
+		}
+		// NEW_SERVER_ADAPTER add logic for new adapter here
+		return providers;
+	}
+	
+	/* Essentially, jars for app servers based on AS-6.x or lower */
+	private IRuntimePathProvider[] serverConfigDeployJars(IRuntimeType rt) {
+		ArrayList<RuntimePathProviderFileset> sets = new ArrayList<RuntimePathProviderFileset>();
+		sets.add(new RuntimePathProviderFileset(COMMON));
+		sets.add(new RuntimePathProviderFileset(LIB));
+		sets.add(new RuntimePathProviderFileset(CONFIG_DIR + SEP + LIB));
+		sets.add(new RuntimePathProviderFileset(CONFIG_DIR + SEP + DEPLOY + SEP + LIB));
+		sets.add(new RuntimePathProviderFileset(CONFIG_DIR + SEP + DEPLOY + SEP + "jbossweb.sar")); //$NON-NLS-1$
+		sets.add(new RuntimePathProviderFileset(CONFIG_DIR + SEP + DEPLOYERS));
+		sets.add(new RuntimePathProviderFileset(CLIENT));
+		return sets.toArray(new RuntimePathProviderFileset[sets.size()]);
+	}
+
+	/* Essentially, jars for app servers based on AS-7 or higher */
+	private IRuntimePathProvider[] configDeploymentsJars(IRuntimeType rt) {
+		ArrayList<RuntimePathProviderFileset> sets = new ArrayList<RuntimePathProviderFileset>();
+		sets.add(new RuntimePathProviderFileset("jboss-modules.jar"));
+		sets.add(new RuntimePathProviderFileset("modules"));
+		sets.add(new RuntimePathProviderFileset("bundles"));
+		return sets.toArray(new RuntimePathProviderFileset[sets.size()]);
+	}
+}

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/extensions/descriptors/XPathQuery.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/extensions/descriptors/XPathQuery.java
@@ -17,9 +17,6 @@ import java.util.Map;
 
 import org.dom4j.Document;
 import org.dom4j.Node;
-import org.eclipse.core.internal.variables.StringSubstitutionEngine;
-import org.eclipse.core.internal.variables.StringVariableManager;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.wst.server.core.IServer;
@@ -27,10 +24,10 @@ import org.jaxen.JaxenException;
 import org.jaxen.SimpleNamespaceContext;
 import org.jaxen.XPath;
 import org.jaxen.dom4j.Dom4jXPath;
-import org.jboss.ide.eclipse.as.core.JBossServerCorePlugin;
 import org.jboss.ide.eclipse.as.core.extensions.descriptors.XPathFileResult.XPathResultNode;
-import org.jboss.ide.eclipse.as.core.resolvers.ConfigNameResolver;
+import org.jboss.ide.eclipse.as.core.resolvers.RuntimeVariableResolver;
 import org.jboss.ide.eclipse.as.core.util.IMemento;
+import org.jboss.tools.foundation.core.expressions.ExpressionResolver;
 
 /**
  * A simple value object to hold the XPath query data
@@ -101,10 +98,15 @@ public class XPathQuery implements Serializable {
 		setEffectiveFilePattern();
 	}
 	
+	private String getReplacedString(String original) {
+		 RuntimeVariableResolver resolver = new RuntimeVariableResolver(server.getRuntime());
+		 ExpressionResolver process = new ExpressionResolver(resolver);
+		 return process.resolve(original);
+	}
+	
 	private void setEffectiveBaseDir() {
-		String serverName = server == null ? "" : server.getName(); //$NON-NLS-1$
 		String dir1 = baseDir == null ? null : baseDir;
-		String dir2 = new ConfigNameResolver().performSubstitutions(dir1, serverName);
+		String dir2 = getReplacedString(dir1);
 		IPath dir = dir2 == null ? null : new Path(dir2);
 		if( dir == null && category != null) {
 			dir = getCategory().getServer().getRuntime().getLocation();
@@ -115,9 +117,8 @@ public class XPathQuery implements Serializable {
 	}
 	
 	private void setEffectiveFilePattern() {
-		String serverName = server == null ? "" : server.getName(); //$NON-NLS-1$
 		String pattern = filePattern == null ? null : filePattern;
-		String pattern2 = new ConfigNameResolver().performSubstitutions(pattern, serverName);
+		String pattern2 = getReplacedString(pattern);
 		effectiveFilePattern = pattern2;
 	}
 	

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/resolvers/ConfigNameResolver.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/resolvers/ConfigNameResolver.java
@@ -132,8 +132,8 @@ public class ConfigNameResolver implements IDynamicVariableResolver {
 	}
 
 	private String handleServerHome(String variable, String argument) {
-		IJBossServerRuntime ajbsrt = findJBossServerRuntime(argument);
-		return ajbsrt.getRuntime().getLocation().toOSString();
+		IRuntime rt = findServerRuntime(argument);
+		return rt.getLocation().toOSString();
 	}
 	
 	private String handleConfig(String variable, String argument) {
@@ -173,19 +173,33 @@ public class ConfigNameResolver implements IDynamicVariableResolver {
 	 * @return
 	 */
 	private IJBossServerRuntime findJBossServerRuntime(String serverOrRuntimeName) {
+		return (IJBossServerRuntime)findServerRuntime(serverOrRuntimeName, true);
+	}
+	
+	private IRuntime findServerRuntime(String serverOrRuntimeName) {
+		return (IRuntime)findServerRuntime(serverOrRuntimeName, false);
+	}
+	
+	
+	private Object findServerRuntime(String serverOrRuntimeName, boolean adapt) {
 		IServer[] servers = ServerCore.getServers();
 		for( int i = 0; i < servers.length; i++ ) {
 			if( servers[i].getName().equals(serverOrRuntimeName)) {
-				if( servers[i].getRuntime() != null )
-					return  (IJBossServerRuntime) servers[i].getRuntime()
-							.loadAdapter(IJBossServerRuntime.class, new NullProgressMonitor());
+				if( servers[i].getRuntime() != null ) {
+					if( adapt )
+						return  (IJBossServerRuntime) servers[i].getRuntime()
+								.loadAdapter(IJBossServerRuntime.class, new NullProgressMonitor());
+					return servers[i].getRuntime();
+				}
 			}
 		}
 		IRuntime[] runtimes = ServerCore.getRuntimes();
 		for( int i = 0; i < runtimes.length; i++ ) {
 			if( runtimes[i].getName().equals(serverOrRuntimeName)) {
-				return (IJBossServerRuntime) runtimes[i]
-						.loadAdapter(IJBossServerRuntime.class, new NullProgressMonitor());
+				if( adapt )
+					return (IJBossServerRuntime) runtimes[i]
+							.loadAdapter(IJBossServerRuntime.class, new NullProgressMonitor());
+				return runtimes[i];
 			}
 		}
 		return null;

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossExtendedProperties.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossExtendedProperties.java
@@ -23,6 +23,7 @@ import org.eclipse.osgi.util.NLS;
 import org.jboss.ide.eclipse.as.core.JBossServerCorePlugin;
 import org.jboss.ide.eclipse.as.core.Messages;
 import org.jboss.ide.eclipse.as.core.resolvers.ConfigNameResolver;
+import org.jboss.ide.eclipse.as.core.resolvers.RuntimeVariableResolver;
 import org.jboss.ide.eclipse.as.core.server.IDefaultLaunchArguments;
 import org.jboss.ide.eclipse.as.core.server.IDeploymentScannerModifier;
 import org.jboss.ide.eclipse.as.core.server.IServerModuleStateVerifier;
@@ -33,6 +34,7 @@ import org.jboss.ide.eclipse.as.core.server.internal.JMXServerDeploymentScannerA
 import org.jboss.ide.eclipse.as.core.util.IJBossRuntimeResourceConstants;
 import org.jboss.ide.eclipse.as.core.util.IJBossToolingConstants;
 import org.jboss.ide.eclipse.as.core.util.ServerUtil;
+import org.jboss.tools.foundation.core.expressions.ExpressionResolver;
 
 /**
  * The superclass containing most functionality, to be overridden as necessary.
@@ -72,8 +74,9 @@ public class JBossExtendedProperties extends ServerExtendedProperties {
 	public String getServerDeployLocation() {
 		String original = ConfigNameResolver.getVariablePattern(ConfigNameResolver.JBOSS_CONFIG_DIR) +
 				"/" + IJBossRuntimeResourceConstants.DEPLOY;  //$NON-NLS-1$
-		return new ConfigNameResolver().performSubstitutions(
-				original, server.getName());
+		 RuntimeVariableResolver resolver = new RuntimeVariableResolver(runtime);
+		 ExpressionResolver process = new ExpressionResolver(resolver);
+		 return process.resolve(original);
 	}
 
 	public int getJMXProviderType() {

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/v7/LocalJBoss7ServerRuntime.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/v7/LocalJBoss7ServerRuntime.java
@@ -13,16 +13,11 @@ package org.jboss.ide.eclipse.as.core.server.internal.v7;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.jdt.internal.launching.environments.EnvironmentsManager;
-import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
-import org.eclipse.wst.server.core.IRuntimeType;
 import org.jboss.ide.eclipse.as.core.server.IJBossServerRuntime;
 import org.jboss.ide.eclipse.as.core.server.internal.LocalJBossServerRuntime;
 import org.jboss.ide.eclipse.as.core.util.IJBossRuntimeConstants;
 import org.jboss.ide.eclipse.as.core.util.IJBossRuntimeResourceConstants;
-import org.jboss.ide.eclipse.as.core.util.JavaUtils;
 
 public class LocalJBoss7ServerRuntime extends LocalJBossServerRuntime implements IJBossRuntimeConstants {
 	public static final String CONFIG_FILE = "org.jboss.ide.eclipse.as.core.server.internal.v7.CONFIG_FILE"; //$NON-NLS-1$

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/dialogs/XPathDialogs.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/dialogs/XPathDialogs.java
@@ -65,10 +65,12 @@ import org.jboss.ide.eclipse.as.core.extensions.descriptors.XPathFileResult.XPat
 import org.jboss.ide.eclipse.as.core.extensions.descriptors.XPathModel;
 import org.jboss.ide.eclipse.as.core.extensions.descriptors.XPathQuery;
 import org.jboss.ide.eclipse.as.core.resolvers.ConfigNameResolver;
+import org.jboss.ide.eclipse.as.core.resolvers.RuntimeVariableResolver;
 import org.jboss.ide.eclipse.as.core.server.internal.JBossServer;
 import org.jboss.ide.eclipse.as.core.server.internal.extendedproperties.ServerExtendedProperties;
 import org.jboss.ide.eclipse.as.core.util.ServerConverter;
 import org.jboss.ide.eclipse.as.ui.Messages;
+import org.jboss.tools.foundation.core.expressions.ExpressionResolver;
 
 
 /**
@@ -369,6 +371,13 @@ public class XPathDialogs {
 				baseDirText.setText(rootDir);
 			}
 		}
+		
+		private String getReplacedString(String original) {
+			 RuntimeVariableResolver resolver = new RuntimeVariableResolver(server.getRuntime());
+			 ExpressionResolver process = new ExpressionResolver(resolver);
+			 return process.resolve(original);
+		}
+		
 		protected void previewPressed() {
 			if( server == null ) {
 				checkErrors();
@@ -381,14 +390,14 @@ public class XPathDialogs {
 			String directory = baseDirText.getText();
 			
 			// substitute in basedir
-			directory = new ConfigNameResolver().performSubstitutions(directory, server.getName());
+			directory = getReplacedString(directory);
 			if( !new Path(directory).isAbsolute()) {
 				directory = server.getRuntime().getLocation().append(directory).toString();
 			}
 			final String directory2 = directory;
 			
 			// substitute in filePattern
-			filePattern = new ConfigNameResolver().performSubstitutions(filePattern, server.getName());
+			filePattern = getReplacedString(filePattern);
 			final String filePattern2 = filePattern;
 			
 			IRunnableWithProgress op = new IRunnableWithProgress() {

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/ParametizedSuite.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/ParametizedSuite.java
@@ -24,6 +24,7 @@ import org.junit.runners.Suite.SuiteClasses;
 	CreateServerCheckDefaultsTest.class,
 	ServerModeRuntimeDetailsTest.class,
 	ProjectRuntimeClasspathTest.class,
+	RuntimeJarUtilityTest.class, 
 	CreateRuntimeTwiceTest.class,
 	XPathModelTest.class,
 	MockArgsTests.class, 

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/RuntimeJarUtilityTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/parametized/server/RuntimeJarUtilityTest.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.as.test.core.parametized.server;
+
+import java.util.Collection;
+import java.util.HashMap;
+
+import junit.framework.TestCase;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.wst.server.core.IRuntime;
+import org.eclipse.wst.server.core.IServer;
+import org.jboss.ide.eclipse.as.classpath.core.runtime.RuntimeJarUtility;
+import org.jboss.ide.eclipse.as.core.resolvers.ConfigNameResolver;
+import org.jboss.ide.eclipse.as.core.server.IJBossServerRuntime;
+import org.jboss.ide.eclipse.as.core.util.RuntimeUtils;
+import org.jboss.tools.as.test.core.internal.utils.ServerCreationTestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * This class will test properties of a default created server and runtime 
+ * for properties that should never be null.
+ * 
+ * @author rob
+ *
+ */
+@RunWith(value = Parameterized.class)
+public class RuntimeJarUtilityTest extends TestCase {
+	private String serverType;
+	private IServer server;
+	@Parameters
+	public static Collection<Object[]> data() {
+		 return ServerParameterUtils.asCollection(ServerParameterUtils.getJBossServerTypeParameters());
+	}
+	 
+	public RuntimeJarUtilityTest(String serverType) {
+		this.serverType = serverType;
+	}
+	
+	@Before
+	public void setUp() {
+		try {
+			server = ServerCreationTestUtils.createServerWithRuntime(serverType, getClass().getName() + serverType);
+		} catch(CoreException ce) {
+			ce.printStackTrace();
+			fail();
+		}
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ServerCreationTestUtils.deleteAllServersAndRuntimes();
+	}
+	
+	@Test
+	public void testRuntimeJarUtility() {
+		RuntimeJarUtility util = new RuntimeJarUtility();
+		IRuntime rt = server.getRuntime();
+		HashMap<String, String> replacements = new HashMap<String, String>();
+		replacements.put(ConfigNameResolver.JBOSS_CONFIG_DIR, getConfigDir());
+		
+		IPath[] result1 = util.getJarsForRuntime(rt, util.CLASSPATH_JARS);
+		assertNotNull(result1);
+		assertTrue(result1.length > 0);
+		checkAllValid(result1);
+		
+		IPath[] result2 = util.getJarsForRuntimeHome(rt.getLocation().toString(), util.CLASSPATH_JARS, replacements);
+		assertNotNull(result2);
+		assertTrue(result2.length > 0);
+		checkAllValid(result2);
+		
+		replacements.put(ConfigNameResolver.JBOSS_CONFIG_DIR, "/home/garbage/does/not/exist");
+		IPath[] result3 = util.getJarsForRuntimeHome("/home/garbage/does/not/exist", util.CLASSPATH_JARS, replacements);
+		assertNull(result3);
+		
+	}
+	
+	private static void checkAllValid(IPath[] paths) {
+		for( int i = 0; i < paths.length; i++ ) {
+			assertTrue(paths[i].isAbsolute());
+			assertTrue(paths[i].toFile().exists());
+		}
+	}
+	
+	protected String getConfigDir() {
+		IJBossServerRuntime ajbsrt = getJBossRuntime(server);
+		if( ajbsrt != null ) {
+			String config = null;
+			if( ajbsrt != null ) 
+				config = ajbsrt.getConfigLocationFullPath().append(ajbsrt.getJBossConfiguration()).toString();
+			if( config != null )
+				return config;
+		}
+		return null;
+	}
+
+	private IJBossServerRuntime getJBossRuntime(IServer s) {
+		return RuntimeUtils.getJBossServerRuntime(s.getRuntime());
+	}
+}


### PR DESCRIPTION
This patch performs the following:

1) Moves 4 classes from o.j.i.e.as.classpath.core.runtimes to o.j.i.e.as.classpath.core.runtimes.internal
2) Moves Messages and Messages.proprties to o.j.i.e.as.classpath.core.internal
3) Removes 2 methods in ClasspathCorePlugin which expose internal classes in official api (API LEAK)
4) Moves most of CustomRuntimeClasspathModel's methods into an internal class as implementation details. 
5) Moves CustomRuntimeClasspathModel.IDefaultPathProvider interface into its own class IRuntimetPathProvider
6) Moves internal class CustomRuntimeClasspathModel.PathProviderFileset to RuntimePathProviderFileset
7) adds methods to RuntimePathPRoviderFileset to allow for resolution without an IRuntime
8) Adds test case for all changes. 

This counts as several large API changes, though there are NO clients outside of jbosstools-server repository. Moving Messages class counts as an API change. Moving the 4 classes mentioned in step 1) count as API changes. Removing the 2 api-leak methods in step 3) count as api change. Step 4) counts as API change (many public methods (whch should never have been public) were moved. Step 5) is API change. Moving inner-class interfaces and impls' are API change. 

So, it's a lot of API changes, but with almost no consumers. However, the added test case shows that we can now retrieve a set of jars either an IRuntime or a server home location separate from an IRuntime. So, this is very good. 
