### PR TITLE
JBIDE-15901 maint - remote jmx not working for wf/eap6.x

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/JBossServer.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/JBossServer.java
@@ -235,19 +235,43 @@ public class JBossServer extends DeployableServer
 	}
 	
 	// first class parameters
+	@Override
 	public String getUsername() {
 		return getAttribute(SERVER_USERNAME, "admin"); //$NON-NLS-1$
 	}
+	
+	/**
+	 * Get this value raw, as it is currently stored, with no defaults 
+	 * @return
+	 */
+	public String getRawUsername() {
+		return getAttribute(SERVER_USERNAME, (String)null);
+	}
+
+	
 	public void setUsername(String name) {
 		setAttribute(SERVER_USERNAME, name);
 	}
-
+	
+	@Override
 	public String getPassword() {
 		String s = ServerUtil.getFromSecureStorage(getServer(), SERVER_PASSWORD);
 		if( s == null )
 			return getAttribute(SERVER_PASSWORD, "admin"); //$NON-NLS-1$
 		return s;
 	}
+	
+	/**
+	 * Get this password as it is currently stored, without any default values appended
+	 */
+	public String getRawPassword() {
+		String s = ServerUtil.getFromSecureStorage(getServer(), SERVER_PASSWORD);
+		if( s == null )
+			return getAttribute(SERVER_PASSWORD, (String)null);
+		return s;
+	}
+
+	
 	public void setPassword(String pass) {
 		try {
 			ServerUtil.storeInSecureStorage(getServer(), SERVER_PASSWORD, pass);

--- a/as/plugins/org.jboss.ide.eclipse.as.jmx.integration/src/org/jboss/ide/eclipse/as/jmx/integration/JMXSafeRunner.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.jmx.integration/src/org/jboss/ide/eclipse/as/jmx/integration/JMXSafeRunner.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.wst.server.core.IServer;
-import org.jboss.ide.eclipse.as.core.util.ServerConverter;
 import org.jboss.tools.jmx.core.ExtensionManager;
 import org.jboss.tools.jmx.core.IConnectionWrapper;
 import org.jboss.tools.jmx.core.IJMXRunnable;
@@ -26,8 +25,8 @@ public class JMXSafeRunner {
 	
 	public JMXSafeRunner(IServer s) {
 		this.server = s;
-		user = ServerConverter.getJBossServer(s).getUsername();
-		pass = ServerConverter.getJBossServer(s).getPassword();
+		user = null;
+		pass = null;
 	}
 	
 	public void setUser(String user) {
@@ -42,9 +41,7 @@ public class JMXSafeRunner {
 	}
 	
 	public static void run(IServer s, IJMXRunnable r) throws JMXException {
-		String user = ServerConverter.getJBossServer(s).getUsername();
-		String pass = ServerConverter.getJBossServer(s).getPassword();
-		run(s,r,user,pass);
+		run(s,r,null, null);
 	}
 	
 	public static void run(IServer s, IJMXRunnable r, String user, String pass) throws JMXException {


### PR DESCRIPTION
A credentialing issue has re-surfaced and is a regression due to a bad patch previously applied. 
