### PR TITLE
JBIDE-15139 error on recursive adding of missing parent folders for matched files

### DIFF
--- a/archives/plugins/org.jboss.ide.eclipse.archives.core/src/main/org/jboss/ide/eclipse/archives/core/model/DirectoryScannerFactory.java
+++ b/archives/plugins/org.jboss.ide.eclipse.archives.core/src/main/org/jboss/ide/eclipse/archives/core/model/DirectoryScannerFactory.java
@@ -252,6 +252,7 @@ public class DirectoryScannerFactory {
 	    		if( requiredFolders.get(includedFile.getAbsolutePath()) != null )
 	    			return; // all done
 	    		addMatchToMap(includedFile, requiredFolders);
+	    		tmpParentWrapper = includedFile.getParentFile();
 	    	}
 	    }
 	    


### PR DESCRIPTION
Seems our virtual component here will correctly match all files via the project archives "directory scanner" apis, but the problem comes during conversion to the IVirtualComponent.

If we have a matched file foo/a/b/c/Bar.class, we attempt to mark foo/a/b/c, foo/a/b, and foo/a as folders that must be made even if empty.

A coding error made the loop end prematurely, missing parent folders.
