### PR TITLE
JBIDE-13405

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/publishers/AbstractServerToolsPublisher.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/publishers/AbstractServerToolsPublisher.java
@@ -152,7 +152,7 @@ public abstract class AbstractServerToolsPublisher implements IJBossServerPublis
 		}
 		if( tree2.length == 0 ) 
 			return new Path(publishMethod.getPublishDefaultRootFolder(server.getServer()));
-		return server.getDeploymentLocation(moduleTree, true);
+		return server.getDeploymentLocation(tree2, true);
 	}
 
 	


### PR DESCRIPTION
Error with nested force-zipped inner deployments (things like utility projects inside other project types). An internal method used to calculate the path returned an incorrect value, but the local deployment was able to treat this value and work around it properly, while RSE was not. 
