### PR TITLE
JBIDE-16025 do not attempt to change the state of as>7 or deploy-only server's deployment scanners during publish

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.rse.core/src/org/jboss/ide/eclipse/as/rse/core/RSEPublishMethod.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.rse.core/src/org/jboss/ide/eclipse/as/rse/core/RSEPublishMethod.java
@@ -38,6 +38,7 @@ import org.jboss.ide.eclipse.as.core.server.IJBoss6Server;
 import org.jboss.ide.eclipse.as.core.server.IPublishCopyCallbackHandler;
 import org.jboss.ide.eclipse.as.core.server.internal.DelegatingServerBehavior;
 import org.jboss.ide.eclipse.as.core.server.internal.JBossServer;
+import org.jboss.ide.eclipse.as.core.server.internal.extendedproperties.JBossExtendedProperties;
 import org.jboss.ide.eclipse.as.core.util.IEventCodes;
 import org.jboss.ide.eclipse.as.core.util.IJBossRuntimeResourceConstants;
 import org.jboss.ide.eclipse.as.core.util.IJBossToolingConstants;
@@ -98,6 +99,11 @@ public class RSEPublishMethod extends AbstractPublishMethod {
 	}
 	
 	protected void startDeploymentScanner() {
+		// This block of code should only be entered for AS < 7, and NOT for deploy-only server
+		JBossExtendedProperties eprops = (JBossExtendedProperties) behaviour.getServer().loadAdapter(JBossExtendedProperties.class, null);
+		if( eprops.getFileStructure() != JBossExtendedProperties.FILE_STRUCTURE_SERVER_CONFIG_DEPLOY)
+			return;
+		
 		Trace.trace(Trace.STRING_FINER, "Starting remote deployment scanner for server " + getServer().getName());
 		String cmd = getDeploymentScannerCommand(new NullProgressMonitor(), true);
 		if( cmd != null )
@@ -105,6 +111,11 @@ public class RSEPublishMethod extends AbstractPublishMethod {
 	}
 
 	protected void stopDeploymentScanner() {
+		// This block of code should only be entered for AS < 7, and NOT for deploy-only server
+		JBossExtendedProperties eprops = (JBossExtendedProperties) behaviour.getServer().loadAdapter(JBossExtendedProperties.class, null);
+		if( eprops.getFileStructure() != JBossExtendedProperties.FILE_STRUCTURE_SERVER_CONFIG_DEPLOY)
+			return;
+		
 		Trace.trace(Trace.STRING_FINER, "Stopping remote deployment scanner for server " + getServer().getName());
 		String cmd = getDeploymentScannerCommand(new NullProgressMonitor(), false);
 		if( cmd != null )


### PR DESCRIPTION
The block of code inside RSEPublishMethod attempts to stop and restart the deployment scanners on the remote server. The current implementation is only fit for AS < 7. There does not currently exist an implementation (in our code) for AS>=7.

This block of code is entered, and attempts to ssh into the remote machine, and execute a twiddle command, to turn off (and restart) the scanners. It also delays for 3 seconds hoping that the change goes through.

This code is questionable already for AS < 7, but for AS >= 7, it is only a wasted 3-second delay with no purpose at all. Deploy-only servers also suffer from this delay, and deploy-only servers have no such scanners to even be turned off.

Since larger-scale refactors are not currently possible at this time, the best solution is to simply exit the block of code early if the target server is not < AS7.
