### PR TITLE
JBIDE-16865 maint

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.core/plugin.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/plugin.xml
@@ -1817,7 +1817,7 @@
           point="org.jboss.ide.eclipse.as.wtp.core.serverProfile">
        <serverProfile id="local.mgmt" serverTypes="%ServerTypesJBoss7OrHigher">
           <initializer class="org.jboss.tools.as.core.server.controllable.profile.internal.LocalManagementProfileInitializer"/>
-       	  <description name="Local (Prefers Management Operations)" description="A profile configured for use on a local machine, preferring management operations wherever possible"/>
+       	  <description name="Local (Use Management Operations)" description="A profile configured for use on a local machine, using management operations wherever possible."/>
           <subsystem system="launch" subsystem="launch.standard.local"/>
           <subsystem system="shutdown" subsystem="shutdown.default"/>
           <subsystem system="publish" subsystem="publish.management"/>

--- a/as/plugins/org.jboss.ide.eclipse.as.rse.core/plugin.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.rse.core/plugin.xml
@@ -117,7 +117,7 @@
           point="org.jboss.ide.eclipse.as.wtp.core.serverProfile">
        <serverProfile id="rse.mgmt" serverTypes="%ServerTypesJBoss7OrHigher">
        	  <initializer class="org.jboss.ide.eclipse.as.rse.core.subsystems.RSEManagementProfileInitializer"/>
-       	  <description name="Remote (Prefers Management Operations)" description="A profile configured for use on a remote machine, preferring management operations wherever possible"/>
+       	  <description name="Remote (Use Management Operations)" description="A profile configured for use on a remote machine, using management operations wherever possible."/>
           <subsystem system="deploymentOptions" subsystem="deploymentOptions.rse"/> <!-- quick workaround JBIDE-16895 -->
           <subsystem system="launch" subsystem="launch.standard.rse"/>
           <subsystem system="publish" subsystem="publish.management"/>

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/wizards/ServerProfileWizardFragment.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/wizards/ServerProfileWizardFragment.java
@@ -89,9 +89,26 @@ public class ServerProfileWizardFragment extends WizardFragment implements IComp
 	public ServerProfileWizardFragment() {
 		super();
 	}
+	
+	@Override
 	public void setComplete(boolean complete) {
 		super.setComplete(complete);
 	}
+
+	@Override
+	public boolean isComplete() {
+		return !hasDisposedWidgets() && super.isComplete();
+	}
+	
+	/*
+	 * Wizard fragments are re-used. This means the only way we can check if this is being used in a new wizard, or 
+	 * in a previous wizard, is to check whether any widgets are now disposed.  We'll check the most common widget, 
+	 * the description label. 
+	 */
+	protected boolean hasDisposedWidgets() {
+		return serverExplanationLabel.isDisposed();
+	}
+	
 	public Composite createComposite(Composite parent, IWizardHandle handle) {
 		this.handle = handle;
 		
@@ -394,11 +411,7 @@ public class ServerProfileWizardFragment extends WizardFragment implements IComp
 		super.performCancel(monitor);
 		trackNewServerEvent(0);
 	}
-
-	public boolean isComplete() {
-		return super.isComplete();
-	}
-
+	
 	public boolean hasComposite() {
 		return true;
 	}


### PR DESCRIPTION
Servertools (for some unknown reason) only instantiates each wizard fragment (basically, wizard page) once. This makes it difficult to keep state here, or know exactly when to reset state.  After a user has already made an AS7.1 server, for example,  the next time they attempt to make one, the existing fragment is re-used. All of the widgets are currently disposed. But, the page is expected to know whether or not the page is complete BEFORE the user enters the page. and thus, before the composite (and new widgets) have been created. 

Pain in the butt, for sure. Easy workaround though. 
