### PR TITLE
JBIDE-17396 - support for patched wf 8.1.0

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.classpath.core/src/org/jboss/ide/eclipse/as/classpath/core/runtime/cache/internal/ModuleSlot.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.classpath.core/src/org/jboss/ide/eclipse/as/classpath/core/runtime/cache/internal/ModuleSlot.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.wst.server.core.IRuntime;
-import org.jboss.ide.eclipse.as.classpath.core.runtime.jbossmodules.internal.LayeredModulePathFactory;
+import org.jboss.ide.eclipse.as.core.server.jbossmodules.LayeredModulePathFactory;
 
 /**
  * This class represents a module + slot combination

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/META-INF/MANIFEST.MF
@@ -31,6 +31,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.jboss.ide.eclipse.as.core.server,
  org.jboss.ide.eclipse.as.core.server.bean,
+ org.jboss.ide.eclipse.as.core.server.jbossmodules;x-internal:=true,
  org.jboss.ide.eclipse.as.core.util,
  org.jboss.ide.eclipse.as.wtp.core.modules,
  org.jboss.ide.eclipse.as.wtp.core.server.behavior,

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/JBossServerType.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/JBossServerType.java
@@ -74,7 +74,7 @@ public class JBossServerType extends ServerBeanType implements IJBossToolingCons
 
 	@Deprecated
 	protected String[] versions = new String[0];
-	protected JBossServerType(String id, String name, String jbossSystemJarPath, String[] versions, Condition condition) {
+	protected JBossServerType(String id, String name, String jbossSystemJarPath, String[] versions, ICondition condition) {
 		super(id, name, jbossSystemJarPath, condition);
 		this.versions = versions;
 	}
@@ -83,109 +83,4 @@ public class JBossServerType extends ServerBeanType implements IJBossToolingCons
 	public String[] getVersions() {
 		return versions;
 	}
-	
-	
-	@Deprecated
-	static interface Condition extends ICondition {
-	}
-	
-	@Deprecated
-	public static abstract class AbstractCondition 
-		extends org.jboss.ide.eclipse.as.core.server.bean.AbstractCondition 
-		implements Condition {
-
-		public String getFullVersion(File location, File systemFile) {
-			return AbstractCondition.getFullServerVersionFromZipLegacy(systemFile, 
-					getJBossManifestAttributes());
-		}
-		
-		private static String[] getJBossManifestAttributes() {
-			return new String[]{
-					"JBossEAP-Release-Version",
-					"Specification-Version",
-					"Implementation-Version"
-			};
-		}
-	}
-	
-
-	
-	@Deprecated
-	public static class EAPStandaloneServerTypeCondition extends ServerBeanTypeEAPStandalone.EAPStandaloneServerTypeCondition {}
-	@Deprecated
-	public static class ASServerTypeCondition extends ServerBeanTypeAS.ASServerTypeCondition {}
-	@Deprecated
-	public static class AS7ServerTypeCondition extends ServerBeanTypeAS7.AS7ServerTypeCondition {}
-	@Deprecated
-	public static class AS72ServerTypeCondition extends ServerBeanTypeAS72.AS72ServerTypeCondition {}
-	@Deprecated
-	public static class SOAPServerTypeCondition extends ServerBeanTypeSOAP.SOAPServerTypeCondition{}
-	@Deprecated
-	public static class SOAPStandaloneServerTypeCondition extends ServerBeanTypeSOAPStandalone.SOAPStandaloneServerTypeCondition {}
-	@Deprecated
-	public static class EWPTypeCondition extends ServerBeanTypeEWP.EWPTypeCondition {}
-	@Deprecated
-	public static class EPPTypeCondition extends ServerBeanTypeEPP.EPPTypeCondition {}
-	@Deprecated
-	public static class EAPServerTypeCondition extends ServerBeanTypeEAP.EAPServerTypeCondition {}
-	@Deprecated
-	public static class EAP6ServerTypeCondition extends ServerBeanTypeEAP6.EAP6ServerTypeCondition{}
-	@Deprecated
-	public static class EAP61ServerTypeCondition extends ServerBeanTypeEAP61.EAP61ServerTypeCondition {};
-	@Deprecated
-	public static class JPP6ServerTypeCondition extends ServerBeanTypeJPP6.JPP6ServerTypeCondition{};
-	@Deprecated
-	public static class AS7GateInServerTypeCondition extends ServerBeanTypeAS7GateIn.AS7GateInServerTypeCondition {}
-	
-	
-	/* Deprecated methods which are poorly defined  */
-	@Deprecated
-	public static boolean isEAP(File systemJarFile) {
-		String title = getJarProperty(systemJarFile, IMPLEMENTATION_TITLE);
-		return title != null && title.contains("EAP"); //$NON-NLS-1$
-	}
-	
-	@Deprecated
-	public static boolean isEAP6(File systemJarFile) {
-		String value = getJarProperty(systemJarFile, JBEAP_RELEASE_VERSION);
-		if( value != null && value.trim().startsWith("6.")) //$NON-NLS-1$
-				return true;
-		return false;
-	}
-
-	@Deprecated
-	protected static boolean checkAS7StyleVersion(File location, String mainFolder, String property, String propPrefix) {
-		return scanFolderJarsForManifestProp(location, mainFolder, property, propPrefix);
-	}
-		
-	/**
-	 * This method is almost impossible to return accurately.
-	 * AS7 and AS-5 both have the same JBossServerType.name value, "AS", 
-	 * so if a user wishes to get the JBossServerType which corresponds
-	 * to AS7, it is impossible for him to do so. 
-	 * 
-	 * This method really should be deprecated or fixed. 
-	 * 
-	 * @param name
-	 * @return
-	 */
-	@Deprecated
-	public static JBossServerType getType(String name) {
-		if(AS.name.equals(name)) {
-			return AS;
-		} else if(EAP.name.equals(name)) {
-			return EAP;
-		} else if(SOAP.name.equals(name)) {
-			return SOAP;
-		} else if(SOAP_STD.name.equals(name)) {
-			return SOAP_STD;
-		} else if(EWP.name.equals(name)) {
-			return EWP;
-		} else if(EPP.name.equals(name)) {
-			return EPP;
-		}
-		// TODO externalize
-		throw new IllegalArgumentException("Name '" + name + "' cannot be converted to ServerType"); //$NON-NLS-1$ //$NON-NLS-2$
-	}
-
 }

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBean.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBean.java
@@ -24,10 +24,6 @@ public class ServerBean {
 	private String version = EMPTY;
 	private String fullVersion = EMPTY;
 	
-	@Deprecated 
-	public ServerBean() {
-	}
-	
 	public ServerBean(String location, String name, ServerBeanType type,
 			String fullVersion) {
 		super();

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanExtensionManager.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanExtensionManager.java
@@ -1,3 +1,14 @@
+/******************************************************************************* 
+ * Copyright (c) 2014 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+
 package org.jboss.ide.eclipse.as.core.server.bean;
 
 import java.util.ArrayList;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeJPP61.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeJPP61.java
@@ -29,7 +29,7 @@ public class ServerBeanTypeJPP61 extends ServerBeanTypeUnknownAS71Product {
 		public boolean isServerRoot(File location) {
 			if( "JPP".equalsIgnoreCase(getSlot(location))) {
 				String v = getFullVersion(location, null);
-				return v != null && v.startsWith("6.");
+				return v != null && v.startsWith("6.") && !v.startsWith("6.0");
 			}
 			return false;
 		}

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeSOA6.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeSOA6.java
@@ -10,6 +10,8 @@
  ******************************************************************************/ 
 package org.jboss.ide.eclipse.as.core.server.bean;
 
+import java.io.File;
+
 import org.jboss.ide.eclipse.as.core.server.bean.ServerBeanTypeUnknownAS72Product.UnknownAS72ProductServerTypeCondition;
 import org.jboss.ide.eclipse.as.core.util.IJBossToolingConstants;
 
@@ -24,10 +26,8 @@ public class ServerBeanTypeSOA6 extends ServerBeanTypeUnknownAS71Product {
 			return IJBossToolingConstants.SERVER_EAP_61;
 		}
 		@Override
-		protected String[] getManifestFoldersToFindVersion(String productSlot, String[] layers) {
-			if( !"soa".equals(productSlot))
-				return new String[0];
-			return super.getManifestFoldersToFindVersion(productSlot, layers);
+		public boolean isServerRoot(File location) {
+			return "soa".equals(getSlot(location)) && super.isServerRoot(location);
 		}
 	}
 }

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeUnknownAS71Product.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeUnknownAS71Product.java
@@ -23,11 +23,11 @@ public class ServerBeanTypeUnknownAS71Product extends JBossServerType {
 				new UnknownAS71ProductServerTypeCondition());
 	}
 	
-	public ServerBeanTypeUnknownAS71Product(String path, Condition condition) {
+	public ServerBeanTypeUnknownAS71Product(String path, ICondition condition) {
 		this("AS-Product", "Application Server",path, condition);
 	}
 	
-	protected ServerBeanTypeUnknownAS71Product(String id, String desc, String path, Condition condition) {
+	protected ServerBeanTypeUnknownAS71Product(String id, String desc, String path, ICondition condition) {
 		this( id, desc, path, new String[]{}, condition);
 	}
 	
@@ -35,7 +35,7 @@ public class ServerBeanTypeUnknownAS71Product extends JBossServerType {
 	 * @since 3.0 (actually 2.4.101)
 	 */
 	protected ServerBeanTypeUnknownAS71Product(String id, String desc, String path, 
-			String[] version, Condition condition) {
+			String[] version, ICondition condition) {
 		super( id, desc, path, version, condition);
 	}
 	
@@ -51,15 +51,14 @@ public class ServerBeanTypeUnknownAS71Product extends JBossServerType {
 		@Override
 		public String getFullVersion(File location, File systemJarFile) {
 			String productSlot = getSlot(location);
-			String[] layers = getLayers(location);
-			String[] manifestFolders = getManifestFoldersToFindVersion(productSlot, layers == null ? new String[0] : layers);
-			for( int i = 0; i < manifestFolders.length; i++ ) {
-				String versionInManifest = getEAP6xVersionNoSlotCheck(location, 
-						manifestFolders[i], null, null);
-				if( versionInManifest != null )
-					return versionInManifest;
+			String product = "org.jboss.as.product";
+			if( productSlot != null ) {
+				product += "." + productSlot;
 			}
-			return null;
+			product += ".dir";
+			File[] modules = new File[]{new File(location, "modules")};
+			String vers = ServerBeanType.getManifestPropFromJBossModulesFolder(modules, product, "META-INF", "JBoss-Product-Release-Version");
+			return vers;
 		}
 		
 		/**

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeUnknownAS72Product.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeUnknownAS72Product.java
@@ -10,7 +10,7 @@
  ******************************************************************************/ 
 package org.jboss.ide.eclipse.as.core.server.bean;
 
-import java.util.ArrayList;
+import java.io.File;
 
 import org.jboss.ide.eclipse.as.core.util.IJBossToolingConstants;
 
@@ -21,35 +21,29 @@ public class ServerBeanTypeUnknownAS72Product extends ServerBeanTypeUnknownAS71P
 				new UnknownAS72ProductServerTypeCondition());
 	}
 	public static class UnknownAS72ProductServerTypeCondition extends UnknownAS71ProductServerTypeCondition {
+
+		@Override
+		public boolean isServerRoot(File location) {
+			return server72OrHigher(location) && getFullVersion(location, null) != null;
+		}
+		
+		protected boolean server72OrHigher(File loc) {
+			File[] mods = new File[]{new File(loc, "modules")};
+			String serverVersion = getManifestPropFromJBossModules(mods, "org.jboss.as.server", "main", "JBoss-Product-Release-Version");
+			if( serverVersion == null ) {
+				serverVersion = getManifestPropFromJBossModules(mods, "org.jboss.as.server", "main", "Implementation-Version");
+			}
+			if( serverVersion != null && serverVersion.length() > 3) {
+				if( serverVersion.startsWith("7.") && "2".compareTo(""+serverVersion.charAt(2)) <= 0) {
+					return true;
+				}
+			}
+			return false;
+		}
+		
 		@Override
 		public String getServerTypeId(String version) {
 			return IJBossToolingConstants.SERVER_EAP_61;
 		}
-		@Override
-		protected String[] getManifestFoldersToFindVersion(String productSlot, String[] layers) {
-			ArrayList<String> l = new ArrayList<String>(layers.length);
-			for( int i = 0; i < layers.length; i++ ) {
-				l.add(getMetaInfFolderForLayer(layers[i], productSlot));
-			}
-			l.add(getMetaInfFolderForSlot(productSlot));
-			return (String[]) l.toArray(new String[l.size()]);
-		}
-		@Override
-		protected String getMetaInfFolderForSlot(String slot) {
-			return "modules/system/layers/base/org/jboss/as/product/" + slot + "/dir/META-INF"; //$NON-NLS-1$
-		}
-		
-		/* Incorrect implementation, but cannot remove it because it's officially api */
-		@Deprecated
-		protected String getMetaInfFolderForLayer(String layer) {
-			return getMetaInfFolderForLayer(layer, layer);
-		}
-		/**
-		 * @since 2.5
-		 */
-		protected String getMetaInfFolderForLayer(String layer, String slot) {
-			return "modules/system/layers/" + layer + "/org/jboss/as/product/" + slot + "/dir/META-INF"; //$NON-NLS-1$
-		}
-		
 	}
 }

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeWildfly80.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeWildfly80.java
@@ -26,8 +26,7 @@ public class ServerBeanTypeWildfly80 extends JBossServerType {
 	}
 	public static class Wildfly80ServerTypeCondition extends AbstractCondition {
 		public boolean isServerRoot(File location) {
-			String mainFolder = JBossServerType.WILDFLY80.systemJarPath;
-			return scanFolderJarsForManifestProp(location, mainFolder, AS_RELEASE_MANIFEST_KEY, "8.");
+			return scanManifestPropFromJBossModules(new File[]{new File(location, "modules")}, "org.jboss.as.server", null, AS_RELEASE_MANIFEST_KEY, "8.");
 		}
 		public String getServerTypeId(String version) {	
 			// Just return adapter type wf8 until we discover incompatibility. 

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/jbossmodules/LayeredModulePathFactory.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/jbossmodules/LayeredModulePathFactory.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package org.jboss.ide.eclipse.as.classpath.core.runtime.jbossmodules.internal;
+package org.jboss.ide.eclipse.as.core.server.jbossmodules;
 
 
 import java.io.Closeable;

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/classpath/modules/LayeredModulePathFactoryTest.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/classpath/modules/LayeredModulePathFactoryTest.java
@@ -18,7 +18,7 @@ import junit.framework.TestCase;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.wst.server.core.IRuntime;
 import org.eclipse.wst.server.core.IServer;
-import org.jboss.ide.eclipse.as.classpath.core.runtime.jbossmodules.internal.LayeredModulePathFactory;
+import org.jboss.ide.eclipse.as.core.server.jbossmodules.LayeredModulePathFactory;
 import org.jboss.ide.eclipse.as.core.util.IJBossToolingConstants;
 import org.jboss.tools.as.test.core.internal.utils.ServerCreationTestUtils;
 import org.junit.After;


### PR DESCRIPTION
Switches the underlying implementation of the bean detectors to use LayeredModulePathFactory and find the patches and overlays. 
