### PR TITLE
JBIDE-17552 ewp 5.2 not recognized properly

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/editor/ServerModeSectionComposite.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/editor/ServerModeSectionComposite.java
@@ -176,7 +176,7 @@ public class ServerModeSectionComposite extends Composite {
 	}
 	
 	protected WizardFragment createRootConfigureFragment() {
-		return new LayeredProductServerWizardFragment();
+		return ServerUIPlugin.getWizardFragment( callback.getServer().getServerType().getId());
 	}
 	
 	private void configurePressed() {

--- a/as/plugins/org.jboss.tools.as.runtimes.integration/src/org/jboss/tools/as/runtimes/integration/internal/JBossASHandler.java
+++ b/as/plugins/org.jboss.tools.as.runtimes.integration/src/org/jboss/tools/as/runtimes/integration/internal/JBossASHandler.java
@@ -73,11 +73,12 @@ public class JBossASHandler extends AbstractRuntimeDetectorDelegate implements I
 	public static void createJBossServerFromDefinitions(List<RuntimeDefinition> runtimeDefinitions) {
 		for (RuntimeDefinition runtimeDefinition:runtimeDefinitions) {
 			if (runtimeDefinition.isEnabled()) {
-				File asLocation = getServerAdapterRuntimeLocation(runtimeDefinition);
+				ServerBean sb = new ServerBeanLoader(runtimeDefinition.getLocation()).getServerBean();
+				File asLocation = getServerAdapterRuntimeLocation(sb, runtimeDefinition.getLocation());
 				if (asLocation != null && asLocation.isDirectory()) {
 					String type = runtimeDefinition.getType();
 					if (serverBeanTypeExists(type)) {
-						String typeId = new ServerBeanLoader(asLocation).getServerAdapterId();
+						String typeId = sb.getServerAdapterTypeId();
 						String name = runtimeDefinition.getName();
 						String runtimeName = name + " " + RUNTIME; //$NON-NLS-1$
 						createJBossServer(asLocation, typeId, name, runtimeName);
@@ -308,11 +309,14 @@ public class JBossASHandler extends AbstractRuntimeDetectorDelegate implements I
 	
 	private static File getServerAdapterRuntimeLocation(RuntimeDefinition runtimeDefinitions) {
 		ServerBeanLoader loader = new ServerBeanLoader( runtimeDefinitions.getLocation() );
-		String version = runtimeDefinitions.getVersion();
-		String relative = loader.getServerBean().getType().getRootToAdapterRelativePath(version);
+		return getServerAdapterRuntimeLocation(loader.getServerBean(), runtimeDefinitions.getLocation());
+	}
+	private static File getServerAdapterRuntimeLocation(ServerBean sb, File root) {
+		String version = sb.getVersion();
+		String relative = sb.getBeanType().getRootToAdapterRelativePath(version);
 		if( relative == null )
-			return runtimeDefinitions.getLocation();
-		return new File(runtimeDefinitions.getLocation(), relative);
+			return root;
+		return new File(root, relative);
 	}
 	
 	@Override


### PR DESCRIPTION
JBossASHandler (thing that turns runtime definitions into actual servers) was incorrectly re-fetching the serverbean. but using a modified server home (ie, ewp-5.2.0/jboss-as-web instead of ewp-5.2.0} which was always recognized as an AS installation, not EAP. It was then unable to find version information, and did not make a server
