### PR TITLE
JBIDE-17300 - small changes for better user performance

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.rse.core/src/org/jboss/ide/eclipse/as/rse/core/RSEJBoss7LaunchConfigurator.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.rse.core/src/org/jboss/ide/eclipse/as/rse/core/RSEJBoss7LaunchConfigurator.java
@@ -177,6 +177,6 @@ public class RSEJBoss7LaunchConfigurator implements ILaunchConfigConfigurator {
 	}
 	
 	private boolean isSet(String value) {
-		return value != null && value.length() > 0;
+		return value != null;// && value.length() > 0;
 	}
 }

--- a/as/plugins/org.jboss.ide.eclipse.as.rse.core/src/org/jboss/ide/eclipse/as/rse/core/RSELaunchConfigurator.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.rse.core/src/org/jboss/ide/eclipse/as/rse/core/RSELaunchConfigurator.java
@@ -126,6 +126,6 @@ public class RSELaunchConfigurator implements ILaunchConfigConfigurator {
 	}
 		
 	private boolean isSet(String value) {
-		return value != null  && value.length() > 0;
+		return value != null;//  && value.length() > 0;
 	}
 }


### PR DESCRIPTION
Ensure that a whitespace string for a startup or shutdown command does not get overridden by the default and throws the proper exception.  Also ensure the UI displays a proper warning indicating that empty strings are invalid. 
