### PR TITLE
JBIDE-18252 "Mark as Deployable" does not work in Package Explorer and i...

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/actions/UndeployHandler.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/actions/UndeployHandler.java
@@ -29,7 +29,7 @@ import org.eclipse.ui.handlers.HandlerUtil;
 public class UndeployHandler extends DeployHandler {
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		shell = HandlerUtil.getActiveShell(event);
-		ISelection selection = HandlerUtil.getCurrentSelection(event);
+		ISelection selection = getSelection(event);
 		makeUndeployable(selection);
 		return null;
 	}

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/plugin.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/plugin.xml
@@ -869,51 +869,7 @@
 <extension point="org.eclipse.ui.menus">
 	<menuContribution
 	   allPopups="false"
-	   locationURI="popup:org.eclipse.jdt.ui.PackageExplorer?before=additions">
-	<command
-       commandId="org.jboss.ide.eclipse.as.ui.actions.deploy"
-       icon="icons/publish.gif"
-       id="org.jboss.ide.eclipse.as.ui.actions.Deploy"
-       label="%MakeDeployable"
-       style="push">
-	   <visibleWhen checkEnabled="true" />
-	</command>
-	<command
-       commandId="org.jboss.ide.eclipse.as.ui.actions.undeploy"
-       icon="icons/unpublish.gif"
-       id="org.jboss.ide.eclipse.as.ui.actions.Undeploy"
-       label="%MakeUndeployable"
-       style="push">
-	   <visibleWhen checkEnabled="true" />
-	</command>
-</menuContribution>
-</extension>
-<extension point="org.eclipse.ui.menus">
-	<menuContribution
-	   allPopups="false"
-	   locationURI="popup:org.eclipse.ui.navigator.ProjectExplorer#PopupMenu?before=additions">
-	<command
-       commandId="org.jboss.ide.eclipse.as.ui.actions.deploy"
-       icon="icons/publish.gif"
-       id="org.jboss.ide.eclipse.as.ui.actions.Deploy"
-       label="%MakeDeployable"
-       style="push">
-	   <visibleWhen checkEnabled="true" />
-	</command>
-	<command
-       commandId="org.jboss.ide.eclipse.as.ui.actions.undeploy"
-       icon="icons/unpublish.gif"
-       id="org.jboss.ide.eclipse.as.ui.actions.Undeploy"
-       label="%MakeUndeployable"
-       style="push">
-	   <visibleWhen checkEnabled="true" />
-	</command>
-</menuContribution>
-</extension>
-<extension point="org.eclipse.ui.menus">
-	<menuContribution
-	   allPopups="false"
-	   locationURI="popup:org.eclipse.ui.views.ResourceNavigator?before=additions">
+	   locationURI="popup:org.eclipse.ui.popup.any?before=additions">
 	<command
        commandId="org.jboss.ide.eclipse.as.ui.actions.deploy"
        icon="icons/publish.gif"


### PR DESCRIPTION
...s not visible in Editor context menu

Actions "Mark as Deployable/Undeployable" enabled for all popup menus. Added conerting IJavaProject to IProject in order to work with Package Explorer
