### PR TITLE
JBIDE-18907 - ensure all 'externally managed' servers still have a polle...

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.rse.core/src/org/jboss/ide/eclipse/as/rse/core/StandardRSEJBossStartLaunchDelegate.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.rse.core/src/org/jboss/ide/eclipse/as/rse/core/StandardRSEJBossStartLaunchDelegate.java
@@ -77,13 +77,17 @@ public class StandardRSEJBossStartLaunchDelegate extends
 	}
 	
 	/*
-	 * Below is code for kicking off a poll thread
+	 * Synchronous check to see if server is currently up. 
 	 */
 	@Override
 	protected boolean isStarted(IServer server) {
 		return PollThreadUtils.isServerStarted(server).isOK();
 	}
 	
+	/*
+	 * Kick off a poll thread
+	 */
+	@Override
 	protected void pollServer(IServer server, final boolean expectedState) {
 		PollThreadUtils.pollServer(server, expectedState);
 	}

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/server/launch/AbstractStartJavaServerLaunchDelegate.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/server/launch/AbstractStartJavaServerLaunchDelegate.java
@@ -106,8 +106,9 @@ public abstract class AbstractStartJavaServerLaunchDelegate extends AbstractJava
 		IControllableServerBehavior jbsBehavior = JBossServerBehaviorUtils.getControllableBehavior(server);
 		if (LaunchCommandPreferences.isIgnoreLaunchCommand(server)) {
 			Trace.trace(Trace.STRING_FINEST, "Server is marked as ignore Launch. Marking as started."); //$NON-NLS-1$
-			((ControllableServerBehavior)jbsBehavior).setServerStarted();
 			((ControllableServerBehavior)jbsBehavior).setRunMode(mode);
+			((ControllableServerBehavior)jbsBehavior).setServerStarting();
+			initiatePolling(server);
 			return false;
 		}
 		


### PR DESCRIPTION
...r run against them to verify state, which may prevent subsequent bugs in publishing, deployment scanners, etc
