### PR TITLE
JBIDE-19029 Error: "Attribute name is not allowed to appear in element sub-deployment" in two Seam examples

### DIFF
--- a/as/plugins/org.jboss.tools.as.catalog/schema/xsd/jboss-deployment-structure-1_0.xsd
+++ b/as/plugins/org.jboss.tools.as.catalog/schema/xsd/jboss-deployment-structure-1_0.xsd
@@ -79,7 +79,7 @@
                     </documentation>
                 </annotation>
             </xsd:element>
-            <xsd:element name="sub-deployment" type="deploymentType" minOccurs="0" maxOccurs="unbounded" >
+            <xsd:element name="sub-deployment" type="subDeploymentType" minOccurs="0" maxOccurs="unbounded" >
                 <annotation xmlns="http://www.w3.org/2001/XMLSchema">
                     <documentation>
                         Element that corresponds to a deployment. This is used to customise

--- a/as/tests/org.jboss.ide.eclipse.as.test/.project
+++ b/as/tests/org.jboss.ide.eclipse.as.test/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.jboss.ide.eclipse.as.test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.api.tools.apiAnalysisBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.api.tools.apiAnalysisNature</nature>
+	</natures>
+</projectDescription>

--- a/wtp/tests/org.jboss.tools.wtp.runtimes.tomcat.tests/.project
+++ b/wtp/tests/org.jboss.tools.wtp.runtimes.tomcat.tests/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.jboss.tools.wtp.runtimes.tomcat.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
Copy of schema jboss-deployment-structure-1_0.xsd is fixed to prevent the error.
If runtime supports this attribute then there is no reason for a bad schema
to scream error.