### PR TITLE
4.2.x failing unit tests on jenkins

### DIFF
--- a/as/tests/org.jboss.ide.eclipse.as.management.as7.tests/src/org/jboss/ide/eclipse/as/internal/management/as7/tests/utils/StartupUtility.java
+++ b/as/tests/org.jboss.ide.eclipse.as.management.as7.tests/src/org/jboss/ide/eclipse/as/internal/management/as7/tests/utils/StartupUtility.java
@@ -65,13 +65,7 @@ public class StartupUtility extends Assert {
 		}
 
 		List<String> envp = new ArrayList<String>();
-		if( requiresJava6(rtType) || requiresJava7(rtType)) {
-			String java = System.getProperty(JRE7_SYSPROP);
-			if( java == null || !new File(java).exists()) {
-				fail("Launching " + homeDir + " requires a java7 jdk, which has not been provided via the " + JRE7_SYSPROP + " system property, or does not exist");
-			}
-			envp.add("JAVA_HOME=" + java);
-		} 
+		envp.add("JAVA_HOME=" + getJavaHome(rtType, homeDir));
 		
 		String[] envList = (String[]) envp.toArray(new String[envp.size()]);
 		Process p = null;
@@ -84,6 +78,27 @@ public class StartupUtility extends Assert {
 		System.out.println("Somehow launch completed without returning a process");
 		return null;
 	}
+	
+	private static String getJavaHome(String rtType, String serverHome) {
+		//Currently for all rt types we use java7
+		return getJavaHome(serverHome, JRE7_SYSPROP, "java7 jdk");
+		
+		// In the future we may have some with java8 requirements. 
+	}
+	
+	private static String getJavaHome(String serverHome, String sysprop, String javaVersion) {
+		String java = System.getProperty(sysprop);
+		if( java == null ) {
+			fail("Launching " + serverHome + " requires a " + javaVersion + ", which has not been provided via the " + sysprop + " system property");
+		}
+
+		if( !new File(java).exists()) {
+			fail("Java Home " + java + " provided by the " + sysprop + " system property does not exist.");
+		}
+
+		return java;
+	}
+	
 
 	private String homeDir, runtimeType;
 	private Process process;

--- a/as/tests/org.jboss.ide.eclipse.as.management.as7.tests/src/org/jboss/ide/eclipse/as/internal/management/as7/tests/utils/StartupUtility.java
+++ b/as/tests/org.jboss.ide.eclipse.as.management.as7.tests/src/org/jboss/ide/eclipse/as/internal/management/as7/tests/utils/StartupUtility.java
@@ -43,6 +43,9 @@ public class StartupUtility extends Assert {
 	private static boolean requiresJava7(String runtimeType) {
 		return "JavaSE-1.7".equals(getRequiredExecEnv(runtimeType).getId());
 	}
+	private static boolean requiresJava6(String runtimeType) {
+		return "JavaSE-1.6".equals(getRequiredExecEnv(runtimeType).getId());
+	}
 
 	public static Process runServer(String homeDir) {
 		String rtType = ParameterUtils.serverHomeToRuntimeType.get(homeDir);
@@ -62,13 +65,13 @@ public class StartupUtility extends Assert {
 		}
 
 		List<String> envp = new ArrayList<String>();
-		if( !isJava7() && requiresJava7(rtType)) {
+		if( requiresJava6(rtType) || requiresJava7(rtType)) {
 			String java = System.getProperty(JRE7_SYSPROP);
 			if( java == null || !new File(java).exists()) {
 				fail("Launching " + homeDir + " requires a java7 jdk, which has not been provided via the " + JRE7_SYSPROP + " system property, or does not exist");
 			}
 			envp.add("JAVA_HOME=" + java);
-		}
+		} 
 		
 		String[] envList = (String[]) envp.toArray(new String[envp.size()]);
 		Process p = null;


### PR DESCRIPTION
Several failing management tests. This is the PR to fix it. 

Basically, we launch jboss via shell script in these tests. We (sometimes) pass in a java_home to override the system's default environment variables. This does not happen all the time. This means the initial runs of jboss 7.0 and 7.1 may be launching the shell script and using the default java impl, which could be java6, 7, or 8, depending on the slave.

The fix is to always pass in the java7 as the java-home for now. 

A parallel pull request will be need to be made for master. 