### PR TITLE
[JBIDE-19218] Fix startup extension point error

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/JBossServerUIPlugin.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/JBossServerUIPlugin.java
@@ -37,7 +37,7 @@ import org.osgi.framework.BundleContext;
 /**
  * The main plugin class to be used in the desktop.
  */
-public class JBossServerUIPlugin extends AbstractUIPlugin implements IStartup {
+public class JBossServerUIPlugin extends AbstractUIPlugin {
 
 	private static JBossServerUIPlugin plugin;
 	private ResourceBundle resourceBundle;
@@ -123,10 +123,6 @@ public class JBossServerUIPlugin extends AbstractUIPlugin implements IStartup {
 	 */
 	public ResourceBundle getResourceBundle() {
 		return resourceBundle;
-	}
-
-	public void earlyStartup() {
-		JBossServerCorePlugin.getDefault();
 	}
 	
 	public static void log(String message, Exception e) {

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/JBossServerUIStartup.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/JBossServerUIStartup.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, JBoss Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.ide.eclipse.as.ui;
+
+import org.eclipse.ui.IStartup;
+import org.jboss.ide.eclipse.as.core.JBossServerCorePlugin;;
+
+/**
+ * @author eskimo
+ *
+ */
+public class JBossServerUIStartup implements IStartup {
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.ui.IStartup#earlyStartup()
+	 */
+	@Override
+	public void earlyStartup() {
+		JBossServerCorePlugin.getDefault();
+	}
+
+}

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/plugin.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/plugin.xml
@@ -64,7 +64,8 @@
    </extension>
 
    <extension point="org.eclipse.ui.startup">
-      <startup />
+      <startup
+            class="org.jboss.ide.eclipse.as.ui.JBossServerUIStartup"/>
    </extension>
 
 


### PR DESCRIPTION
Fix extracts ISturtup implementation into separate
class and set its name as startup@class attribute
value in extensin point