### PR TITLE
Define server adapter discovery via p2 property

### DIFF
--- a/as/features/org.jboss.ide.eclipse.as.serverAdapter.wtp.feature/build.properties
+++ b/as/features/org.jboss.ide.eclipse.as.serverAdapter.wtp.feature/build.properties
@@ -1,8 +1,10 @@
 bin.includes = feature.xml,\
                feature.properties,\
-               license.html
+               license.html,\
+               p2.inf
 src.includes = license.html,\
                feature.xml,\
                feature.properties,\
                build.properties,\
+               p2.inf,\
                .project

--- a/as/features/org.jboss.ide.eclipse.as.serverAdapter.wtp.feature/p2.inf
+++ b/as/features/org.jboss.ide.eclipse.as.serverAdapter.wtp.feature/p2.inf
@@ -1,0 +1,2 @@
+ properties.0.name = org.eclipse.wst.server.core.serverAdapter
+ properties.0.value = true


### PR DESCRIPTION
As a consequence of fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=434185 ,
we can now just set the property and directly give JBoss Tools site to webtools
discovery