### PR TITLE
JBIDE-20325 Fixed wrong WildFly string

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeWildfly80.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeWildfly80.java
@@ -18,8 +18,8 @@ public class ServerBeanTypeWildfly80 extends JBossServerType {
 	private static final String AS_RELEASE_MANIFEST_KEY = "JBossAS-Release-Version"; //$NON-NLS-1$
 	public ServerBeanTypeWildfly80() {
 		super(
-				"Wildfly", //$NON-NLS-1$
-				"Wildfly Application Server", //$NON-NLS-1$
+				"WildFly", //$NON-NLS-1$
+				"WildFly Application Server", //$NON-NLS-1$
 				asPath("modules","system","layers","base",
 						"org","jboss","as","server","main"),
 				new String[]{V8_0}, new Wildfly80ServerTypeCondition());

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeWildfly90.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/bean/ServerBeanTypeWildfly90.java
@@ -18,8 +18,8 @@ public class ServerBeanTypeWildfly90 extends JBossServerType {
 	private static final String WF_90_RELEASE_MANIFEST_KEY = "JBoss-Product-Release-Version"; //$NON-NLS-1$
 	public ServerBeanTypeWildfly90() {
 		super(
-				"Wildfly", //$NON-NLS-1$
-				"Wildfly Application Server", //$NON-NLS-1$
+				"WildFly", //$NON-NLS-1$
+				"WildFly Application Server", //$NON-NLS-1$
 				asPath("modules","system","layers","base",
 						"org","jboss","as","server","main"),
 				new String[]{"9.0"}, new Wildfly90ServerTypeCondition());


### PR DESCRIPTION
Some instances of the string WildFly
had lowercase f which resulted in wrong name
of server runtime and server adapter.