### PR TITLE
JBIDE-19637 - downloadruntime hyperlink not working from new server wizard

### DIFF
--- a/as/plugins/org.jboss.tools.as.runtimes.integration/src/org/jboss/tools/as/runtimes/integration/ui/composites/DownloadRuntimeHomeComposite.java
+++ b/as/plugins/org.jboss.tools.as.runtimes.integration/src/org/jboss/tools/as/runtimes/integration/ui/composites/DownloadRuntimeHomeComposite.java
@@ -65,7 +65,14 @@ public class DownloadRuntimeHomeComposite extends RuntimeHomeComposite {
 	}
 
 	protected class DownloadAndInstallListener extends SelectionAdapter {
-		public void widgetSelected(SelectionEvent se) {
+		public void widgetSelected(final SelectionEvent se) {
+			Display.getDefault().asyncExec(new Runnable(){
+				public void run() {
+					widgetSelectedWorkaround(se);
+				}
+			});
+		}
+		public void widgetSelectedWorkaround(SelectionEvent se) {
 			IRuntimeType type = getRuntimeFromTaskModel().getRuntimeType();
 			final DownloadRuntimesTaskWizard wizard = new DownloadRuntimesWizard(downloadAndInstallButton.getShell(), 
 					new JBossASDownloadRuntimeFilter(type));


### PR DESCRIPTION
JBIDE-19637 - downloadruntime hyperlink not working from new server wizard workflow, workaround for osx