### PR TITLE
JBIDE-20549 Fix a typo in variable name in as.core plugin.xml

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.core/plugin.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/plugin.xml
@@ -525,7 +525,7 @@
       <runtimeType
              vendor="%providerName"
              class="org.jboss.ide.eclipse.as.core.server.internal.v7.LocalWildfly80ServerRuntime"
-             description="%jboss.version.wildfly910.description"
+             description="%jboss.version.wildfly10.description"
              name="%jboss.version.wildfly10.runtime.name"
              id="org.jboss.ide.eclipse.as.runtime.wildfly.100"
              version="10.0">


### PR DESCRIPTION
Because of this, in the new runtime wizard the text did not render correctly and the name of the variable was shown instead.