### PR TITLE
Remove redundant trailing space in WildFly 9 name

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.core/plugin.properties
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/plugin.properties
@@ -43,7 +43,7 @@ jboss.version.wildfly8.name=WildFly  8.x
 jboss.version.wildfly8.description=WildFly Application Server 8.x
 jboss.version.wildfly8.runtime.name=WildFly  8.x Runtime
 
-jboss.version.wildfly9.name=WildFly  9.x 
+jboss.version.wildfly9.name=WildFly  9.x
 jboss.version.wildfly9.description=WildFly Application Server 9.x
 jboss.version.wildfly9.runtime.name=WildFly  9.x Runtime
 


### PR DESCRIPTION
We have had a workaround for this in our tests for a while and it's time to remove this redundant space ;)
I traced it back as an omission in https://github.com/robstryker/jbosstools-server/commit/fb2bc2d6a480ebb2129c01039b919b0b3bb33506
when removing "(experimental)" label.