### PR TITLE
JBIDE-21460 NPE at Show In Web Browser for OpenShift server if connection is not connected

### DIFF
--- a/as/itests/org.jboss.tools.as.itests/META-INF/MANIFEST.MF
+++ b/as/itests/org.jboss.tools.as.itests/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Localization: plugin
 Bundle-SymbolicName: org.jboss.tools.as.itests
 Bundle-Version: 3.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.jboss.ide.eclipse.as.core;bundle-version="[3.0.0,4.0.0)",
+Require-Bundle: org.jboss.ide.eclipse.as.core;bundle-version="[3.1.1,4.0.0)",
  org.junit;bundle-version="[4.8.1,5.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",
  org.jboss.ide.eclipse.as.management.core;bundle-version="[3.0.0,4.0.0)",

--- a/as/itests/org.jboss.tools.as.itests/src/org/jboss/tools/as/itests/CreateServerCheckDefaultsTest.java
+++ b/as/itests/org.jboss.tools.as.itests/src/org/jboss/tools/as/itests/CreateServerCheckDefaultsTest.java
@@ -31,6 +31,7 @@ import org.jboss.ide.eclipse.as.core.extensions.descriptors.XPathQuery;
 import org.jboss.ide.eclipse.as.core.server.IJBossServerRuntime;
 import org.jboss.ide.eclipse.as.core.server.internal.ExtendedServerPropertiesAdapterFactory;
 import org.jboss.ide.eclipse.as.core.server.internal.extendedproperties.ServerExtendedProperties;
+import org.jboss.ide.eclipse.as.core.server.internal.extendedproperties.ServerExtendedProperties.GetWelcomePageURLException;
 import org.jboss.ide.eclipse.as.core.server.internal.v7.LocalJBoss7ServerRuntime;
 import org.jboss.ide.eclipse.as.core.util.IJBossToolingConstants;
 import org.jboss.ide.eclipse.as.core.util.RuntimeUtils;
@@ -110,11 +111,13 @@ public class CreateServerCheckDefaultsTest extends TestCase {
 		if( props.canVerifyRemoteModuleState())
 			assertNotNull(props.getModuleStateVerifier());
 		if( props.hasWelcomePage()) {
-			String s = props.getWelcomePageUrl();
 			try {
+				String s = props.getWelcomePageUrl();
 				URL url = new URL(s);
 			} catch(MalformedURLException murle) {
 				fail(serverType + " has an invalid welcome page url: " + murle.getMessage());
+			} catch (GetWelcomePageURLException e) {
+				fail("GetWelcomePageURLException is not expected here: " + e.getMessage());
 			}
 		}
 	}

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/ServerExtendedProperties.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/ServerExtendedProperties.java
@@ -18,6 +18,26 @@ import org.eclipse.wst.server.core.IServer;
 import org.jboss.ide.eclipse.as.core.server.IServerModuleStateVerifier;
 
 public class ServerExtendedProperties {
+
+	/**
+	 * Is thrown when method getWelcomePageUrl() cannot find some resources,
+	 * and there is a reason not to log exception, for example, user 
+	 * declined authentication, or resource is missing in user application.
+	 * This exception will be caught and shown in a warning dialog.
+	 * Otherwise, either NPE error dialog would be shown, or user would 
+	 * not be notified why browser is not open. 
+	 *
+	 */
+	public static class GetWelcomePageURLException extends Exception {
+		private static final long serialVersionUID = -3723110412526178637L;
+
+		public GetWelcomePageURLException(String message) {
+			super(message);
+		}
+		public GetWelcomePageURLException(String message, Throwable cause) {
+			super(message, cause);
+		}
+	}
 	protected IServer server;
 	protected IRuntime runtime;
 	
@@ -70,7 +90,7 @@ public class ServerExtendedProperties {
 		return false;
 	}
 	
-	public String getWelcomePageUrl() {
+	public String getWelcomePageUrl() throws GetWelcomePageURLException {
 		return null;
 	}
 	


### PR DESCRIPTION

ServerExtendedProperties.getWelcomePageUrl() is mode to throw GetWelcomePageURLException
to show message in a warning dialog. Implementation may decide to log problem with stacktrace if
message in dialog is not sufficient.