### PR TITLE
JBIDE-21709 Obstacle with editing user-defined connection

### DIFF
--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/actions/EditConnectionAction.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/actions/EditConnectionAction.java
@@ -13,6 +13,9 @@ package org.jboss.tools.jmx.ui.internal.actions;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.jboss.tools.jmx.core.IConnectionWrapper;
 import org.jboss.tools.jmx.ui.Messages;
 import org.jboss.tools.jmx.ui.internal.wizards.EditConnectionWizard;
@@ -26,8 +29,10 @@ public class EditConnectionAction extends Action {
 		setText(Messages.EditConnectionAction); 
 	}
 	public void run() {
+		IWorkbench wb = PlatformUI.getWorkbench();
+		IWorkbenchWindow win = wb.getActiveWorkbenchWindow();
 		EditConnectionWizard wizard = new EditConnectionWizard(connection);
-		WizardDialog d = new WizardDialog(new Shell(), wizard);
+		WizardDialog d = new WizardDialog(win != null ? win.getShell() : new Shell(), wizard);
 		d.open();
 	}
 }

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/wizards/DefaultConnectionWizardPage.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/wizards/DefaultConnectionWizardPage.java
@@ -355,6 +355,9 @@ public class DefaultConnectionWizardPage extends WizardPage implements
 
 	protected boolean nameTaken(String s) {
 		IConnectionProvider provider = ExtensionManager.getProvider(DefaultConnectionProvider.PROVIDER_ID);
+		if(initialConnection != null && s != null && s.equals(provider.getName(initialConnection))) {
+			return false;
+		}
 		IConnectionWrapper[] connections = provider.getConnections();
 		for( int i = 0; i < connections.length; i++ ) {
 			if( provider.getName(connections[i]).equals(s)) {


### PR DESCRIPTION
1. Checked that name differs from the name of initial connection if it is set.
2. Replaced new Shell() for Edit Connection wizard with active window shell - if new shell was created for a reason, sorry, I will remove that change.