### PR TITLE
JBIDE-21949 - Allow user to turn on/off showing console when output changes

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/IServerConsoleWriter.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/core/server/IServerConsoleWriter.java
@@ -10,6 +10,28 @@
  ******************************************************************************/ 
 package org.jboss.ide.eclipse.as.core.server;
 
+/**
+ * 
+ */
 public interface IServerConsoleWriter extends IJBASHostShellListener {
+	
+	/**
+	 * Writes the given {@code lines} into the {@link MessageConsole} associated with the given {@code serverId}.
+	 * If the {@link MessageConsole} did not exist yet, it is created and shown. Calling this method will activate
+	 * the console while the lines are written.
+	 * 
+	 * @param serverId the id of the server associated with this console.
+	 * @param lines the lines to write in the console.
+	 */
 	public void writeToShell(String serverId, String[] lines);
+	
+	/**
+	 * Writes the given {@code lines} into the {@link MessageConsole} associated with the given {@code serverId}.
+	 * If the {@link MessageConsole} did not exist yet, it is created and shown.
+	 * @param serverId the id of the server associated with this console.
+	 * @param lines the lines to write in the console.
+	 * @param activateOnWrite if the view should be activated when the line are written in the console.
+	 */
+	public void writeToShell(final String serverId, final String[] lines, final boolean activateOnWrite);
+	
 }

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/.classpath
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,12 @@
-#Thu May 21 13:59:37 PDT 2009
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.source=1.7

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/META-INF/MANIFEST.MF
@@ -39,7 +39,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.eclipse.jdt.debug,
  org.eclipse.ui.console;bundle-version="3.6.0"
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: JBoss by Red Hat
 Export-Package: org.jboss.ide.eclipse.as.wtp.ui,
  org.jboss.ide.eclipse.as.wtp.ui.composites,


### PR DESCRIPTION
Changing the code to show the message console when it is created only,
then offering two methods to write lines in the shell and activate the
view or not (default).

Also, upgrading the project's execution environment to Java 1.7 to take
advantage of the 'try-with-resources' statement to make sure that the
outputstream is closed upon writting.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>