### PR TITLE
JBIDE-21994 - Cannot show OpenShift 3 application via live reload

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/ServerExtendedProperties.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/ServerExtendedProperties.java
@@ -10,9 +10,12 @@
  ******************************************************************************/ 
 package org.jboss.ide.eclipse.as.core.server.internal.extendedproperties;
 
+import java.net.URL;
+
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IRuntime;
 import org.eclipse.wst.server.core.IServer;
 import org.jboss.ide.eclipse.as.core.server.IServerModuleStateVerifier;
@@ -134,6 +137,15 @@ public class ServerExtendedProperties {
 	
 	public boolean allowExplodedModulesInEars() {
 		return true;
+	}
+
+	/**
+	 * @param module the IModule to analyze
+	 * @return the root module for the given module. By default, it returns <code>null</code>.
+	 * This method is meant to be overridden. 
+	 */
+	public URL getModuleRootURL(IModule module) {
+		return null;
 	}
 
 }


### PR DESCRIPTION
Adding a new method in the ServerExtendedProperties that will be
overriden by the OpenShift tooling to compute the module context
root (by taking into account all the specificities of the OS3
deployments)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>