### PR TITLE
JBIDE-22016 bump up to use latest parent pom...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.3.1.CR1-SNAPSHOT</version>
+		<version>4.3.1.Final-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>server.all</artifactId>


### PR DESCRIPTION
JBIDE-22016 bump up to use latest parent pom 4.3.1.Final-SNAPSHOT