### PR TITLE
JBIDE-22227 - Ensure hotcode replace functions on local wildfly.

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/launch/StandardLocalJBossStartLaunchDelegate.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/launch/StandardLocalJBossStartLaunchDelegate.java
@@ -10,20 +10,31 @@
  ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.server.internal.launch;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+
+import javax.management.MBeanServerConnection;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
-import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.model.IBreakpoint;
+import org.eclipse.debug.internal.core.BreakpointManager;
+import org.eclipse.jdt.debug.core.IJavaDebugTarget;
+import org.eclipse.jdt.debug.core.IJavaHotCodeReplaceListener;
+import org.eclipse.jdt.debug.core.JDIDebugModel;
 import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.osgi.util.NLS;
+import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IRuntime;
 import org.eclipse.wst.server.core.IServer;
-import org.eclipse.wst.server.core.ServerUtil;
 import org.jboss.ide.eclipse.as.core.JBossServerCorePlugin;
 import org.jboss.ide.eclipse.as.core.Messages;
 import org.jboss.ide.eclipse.as.core.Trace;
 import org.jboss.ide.eclipse.as.core.extensions.events.ServerLogger;
+import org.jboss.ide.eclipse.as.core.server.IJBossServer;
 import org.jboss.ide.eclipse.as.core.server.IJBossServerRuntime;
 import org.jboss.ide.eclipse.as.core.server.IServerStatePoller;
 import org.jboss.ide.eclipse.as.core.server.IUserPrompter;
@@ -39,6 +50,11 @@ import org.jboss.ide.eclipse.as.wtp.core.server.behavior.IControllableServerBeha
 import org.jboss.ide.eclipse.as.wtp.core.server.launch.AbstractStartJavaServerLaunchDelegate;
 import org.jboss.ide.eclipse.as.wtp.core.server.launch.ServerHotCodeReplaceListener;
 import org.jboss.tools.as.core.server.controllable.IDeployableServerBehaviorProperties;
+import org.jboss.tools.foundation.core.plugin.log.StatusFactory;
+import org.jboss.tools.jmx.core.IConnectionFacade;
+import org.jboss.tools.jmx.core.IConnectionWrapper;
+import org.jboss.tools.jmx.core.IJMXRunnable;
+import org.jboss.tools.jmx.core.JMXException;
 
 /**
  * This is a launch configuration delegate for use with local jboss servers. 
@@ -115,4 +131,55 @@ public class StandardLocalJBossStartLaunchDelegate extends
 	protected boolean addCustomHotcodeReplaceLogic(IServer server) {
 		return server.getAttribute(ServerHotCodeReplaceListener.PROPERTY_HOTCODE_REPLACE_OVERRIDE, true);
 	}
+	
+	@Override
+	protected IJavaHotCodeReplaceListener getHotCodeReplaceListener(final IServer server, ILaunch launch) {
+		if( addCustomHotcodeReplaceLogic(server)) {
+			return new ServerHotCodeReplaceListener(server, launch) {
+				protected void postPublish(IJavaDebugTarget target, IModule[] modules) {
+					waitModulesStarted(modules);
+					removeBreakpoints(target);
+					executeJMXGarbageCollection(server, modules);
+					addBreakpoints(target);
+				}
+			};
+		}
+		return null;
+	}
+	
+	protected void addBreakpoints(IJavaDebugTarget target) {
+		IBreakpoint[] breakpoints = DebugPlugin.getDefault().getBreakpointManager().getBreakpoints();
+		for (int i = 0; i < breakpoints.length; i++) {
+			target.breakpointAdded(breakpoints[i]);
+		}
+	}
+
+	protected void removeBreakpoints(IJavaDebugTarget target) {
+		IBreakpoint[] breakpoints = DebugPlugin.getDefault().getBreakpointManager().getBreakpoints();
+		for (int i = 0; i < breakpoints.length; i++) {
+			target.breakpointRemoved(breakpoints[i], null);
+		}
+	}
+
+	protected void executeJMXGarbageCollection(IServer server, IModule[] modules) {
+		IJBossServer jbs = (IJBossServer) server.loadAdapter(IJBossServer.class, null);
+		if (jbs instanceof IConnectionFacade) {
+			IConnectionWrapper wrap = ((IConnectionFacade) jbs).getJMXConnection();
+			try {
+				wrap.run(new IJMXRunnable() {
+					public void run(MBeanServerConnection connection) throws Exception {
+						final MemoryMXBean memoryBean = ManagementFactory.newPlatformMXBeanProxy(connection,
+								ManagementFactory.MEMORY_MXBEAN_NAME, MemoryMXBean.class);
+						memoryBean.gc();
+						memoryBean.gc();
+					}
+				});
+			} catch (JMXException e) {
+				JBossServerCorePlugin.log(
+						StatusFactory.errorStatus(JBossServerCorePlugin.PLUGIN_ID, 
+						"Error executing garbage collection on server after publish", e)); //$NON-NLS-1$
+			}
+		}
+	}
+
 }

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/server/launch/AbstractJavaServerLaunchDelegate.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/server/launch/AbstractJavaServerLaunchDelegate.java
@@ -7,7 +7,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchManager;

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/server/launch/ServerHotCodeReplaceListener.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/server/launch/ServerHotCodeReplaceListener.java
@@ -10,59 +10,67 @@
  ******************************************************************************/
 package org.jboss.ide.eclipse.as.wtp.core.server.launch;
 
+import java.util.Collections;
+
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.jdt.debug.core.IJavaDebugTarget;
 import org.eclipse.jdt.debug.core.IJavaHotCodeReplaceListener;
+import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IServer;
+import org.jboss.ide.eclipse.as.core.server.IServerModuleStateVerifier;
 import org.jboss.ide.eclipse.as.core.server.IUserPrompter;
 import org.jboss.ide.eclipse.as.core.server.UserPrompter;
-import org.jboss.ide.eclipse.as.wtp.core.server.publish.FullPublishJobScheduler;
+import org.jboss.ide.eclipse.as.wtp.core.ASWTPToolsPlugin;
+import org.jboss.ide.eclipse.as.wtp.core.server.behavior.IControllableServerBehavior;
 
 /**
  * A standard hotcode replace listener for servers which will use the userprompt
- * api to present options to the user on how to handle this. 
+ * api to present options to the user on how to handle this.
  * 
- * This class is usable only for servers that are part of the ControllableServer heirarchy
+ * This class is usable only for servers that are part of the ControllableServer
+ * heirarchy
  */
 public class ServerHotCodeReplaceListener implements IJavaHotCodeReplaceListener {
 
 	/**
-	 * Prompt code that will pass 3 arguments: code, server, and exception (or null)
-	 * The result of this prompt must be an integer indicating a suggested action to take
+	 * Prompt code that will pass 3 arguments: code, server, and exception (or
+	 * null) The result of this prompt must be an integer indicating a suggested
+	 * action to take
 	 */
 	public static final int EVENT_HCR_FAIL = 1013;
 	/**
-	 * Prompt code that will pass 3 arguments: code, server, and exception (or null)
-	 * The result of this prompt must be an integer indicating a suggested action to take
+	 * Prompt code that will pass 3 arguments: code, server, and exception (or
+	 * null) The result of this prompt must be an integer indicating a suggested
+	 * action to take
 	 */
 	public static final int EVENT_HCR_OBSOLETE = 1014;
-	
+
 	/**
 	 * The setting on whether or not to override hotcode replace
 	 */
 	public static final String PROPERTY_HOTCODE_REPLACE_OVERRIDE = "org.jboss.ide.eclipse.as.wtp.core.server.launch.OverrideHotCodeReplace";
-	
+
 	/**
 	 * The key representing your new behavior on hotcode failures
 	 */
 	public static final String PROPERTY_HOTCODE_BEHAVIOR = "org.jboss.ide.eclipse.as.wtp.core.server.launch.hotCodeReplace";
-	
-	
+
 	public static final int PROMPT = 0;
 	public static final int RESTART_MODULE = 1;
 	public static final int RESTART_SERVER = 2;
 	public static final int CONTINUE = 3;
 	public static final int TERMINATE = 4;
-	
-	
-	
+
 	private IServer server;
+
 	public ServerHotCodeReplaceListener(IServer server, ILaunch launch) {
 		this.server = server;
 	}
-	
+
 	public void hotCodeReplaceSucceeded(IJavaDebugTarget arg0) {
 		// ignore
 	}
@@ -77,36 +85,78 @@ public class ServerHotCodeReplaceListener implements IJavaHotCodeReplaceListener
 
 	protected void hotCodeError(int code, IJavaDebugTarget target, Exception exception) {
 		int behavior = server.getAttribute(PROPERTY_HOTCODE_BEHAVIOR, PROMPT);
-		if( behavior == PROMPT ) { 
+		if (behavior == PROMPT) {
 			Object result = getPrompter().promptUser(code, server, exception);
-			if( result instanceof Integer) {
-				behavior = ((Integer)result).intValue();
+			if (result instanceof Integer) {
+				behavior = ((Integer) result).intValue();
 			}
 		}
-		if( behavior == RESTART_MODULE) {
-			restartModules();
-		} else if( behavior == RESTART_SERVER) {
+		if (behavior == RESTART_MODULE) {
+			restartModules(target);
+		} else if (behavior == RESTART_SERVER) {
 			restartServer();
-		} else if( behavior == TERMINATE ) {
+		} else if (behavior == TERMINATE) {
 			server.stop(true);
 		}
 		// Continue means ignore
 	}
-	
-	
-	protected void restartModules() {
-		new FullPublishJobScheduler(server, server.getModules()).schedule();
-	}
-	
-	protected void restartServer() {
-		server.restart(server.getMode(), new IServer.IOperationListener(){
+
+	protected void restartModules(final IJavaDebugTarget target) {
+
+		final IModule[] modules = server.getModules();
+		IServer.IOperationListener listener = new IServer.IOperationListener() {
+
 			public void done(IStatus result) {
-				// Ignore
-			}});
+				postPublish(target, modules);
+			}
+		};
+		server.publish(IServer.PUBLISH_FULL, Collections.singletonList(modules), null, listener);
+	}
+
+	/**
+	 * Subclasses can override
+	 * @param target 
+	 * @param modules
+	 */
+	protected void postPublish(IJavaDebugTarget target, IModule[] modules) {
 	}
 	
 	/**
+	 * Currently unused, but used by subclasses
+	 * @param modules
+	 */
+	protected void waitModulesStarted(IModule[] modules) {
+		IControllableServerBehavior controllableBehaviour = (IControllableServerBehavior) server
+				.loadAdapter(IControllableServerBehavior.class, new NullProgressMonitor());
+		if (controllableBehaviour != null) {
+			IServerModuleStateVerifier verifier;
+			try {
+				verifier = (IServerModuleStateVerifier) controllableBehaviour
+						.getController(IControllableServerBehavior.SYSTEM_MODULES);
+				if (verifier != null) {
+					// we can verify the remote state, so go do it, so
+					// go
+					// wait for
+					// the module to be deployed
+					verifier.waitModuleStarted(server, modules, 20000);
+				}
+			} catch (CoreException e) {
+				ASWTPToolsPlugin.pluginLog().logError("Error waiting for modules to start after publish", e);
+			}
+		}
+	}
+	
+	protected void restartServer() {
+		server.restart(server.getMode(), new IServer.IOperationListener() {
+			public void done(IStatus result) {
+				// Ignore
+			}
+		});
+	}
+
+	/**
 	 * Clients can override this method for custom prompt behavior
+	 * 
 	 * @return
 	 */
 	public IUserPrompter getPrompter() {

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/server/publish/FullPublishJobScheduler.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/src/org/jboss/ide/eclipse/as/wtp/core/server/publish/FullPublishJobScheduler.java
@@ -12,6 +12,7 @@ package org.jboss.ide.eclipse.as.wtp.core.server.publish;
 
 import java.util.ArrayList;
 
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IServer;
 import org.eclipse.wst.server.core.internal.PublishServerJob;
@@ -31,13 +32,15 @@ public class FullPublishJobScheduler {
 		this.rootModules = rootModules;
 	}
 	
-	public void schedule() {
+	public Job schedule() {
 		// Make sure all modules are marked as requiring a full publish
 		for( int i = 0; i < rootModules.length; i++ ) {
 			setModuleRequiresFullPublish(rootModules[i]);
 		}
 		// Launch an incremental publish
-		new PublishServerJob(server, IServer.PUBLISH_INCREMENTAL, true).schedule();
+		Job j = new PublishServerJob(server, IServer.PUBLISH_INCREMENTAL, true);
+		j.schedule();
+		return j;
 	}
 	
 	private void setModuleRequiresFullPublish(IModule module) {


### PR DESCRIPTION
This will adjust the behavior of the 'restart module' option in the
hotcode replace dialog to not only republish the modules, but then
wait for the module publish to complete, remove breakpoints,
execute a garbage collection request, and then re-instate the
breakpoints.

Special thanks to Thomas Maeder for the solution.