### PR TITLE
Update url for EAP 7 zip

### DIFF
--- a/as/itests/pom.xml
+++ b/as/itests/pom.xml
@@ -234,7 +234,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<url>http://download.devel.redhat.com/devel/candidates/JBEAP/JBEAP-7.0.0.ER6/jboss-eap-7.0.0.ER6.zip</url>
+							<url>http://download.devel.redhat.com/released/JBEAP-7/7.0.0/jboss-eap-7.0.0.zip</url>
 							<md5>fc8aa269c1ec8bcf8ea9e9b3df74a259</md5>
 							<unpack>true</unpack>
 							<skip>${skipPrivateRequirements}</skip>


### PR DESCRIPTION
The ER5 build is no longer available from that location and we should use GA anyway.