### PR TITLE
JBIDE-23474: Fix reference to resolve parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,18 @@
 			<layout>p2</layout>
 			<url>${jbosstools-base-site}</url>
 		</repository>
+		<!-- To resolve parent artifact -->
+		<repository>
+			<id>jboss-public-repository-group</id>
+			<name>JBoss Public Repository Group</name>
+			<url>http://repository.jboss.org/nexus/content/groups/public/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
 	</repositories>
 </project>
 	


### PR DESCRIPTION
Although it's supposed that environment define the reference
to JBoss Maven repository in the settings.xml, it's missing
often enough to repeat it directly in the pom.xml.
Other JBoss Tools components do define it to remove the requirement
on a settings.xml.