### PR TITLE
Update parent pom to the released version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.4.3.Final-SNAPSHOT</version>
+		<version>4.4.3.Final</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>server.all</artifactId>


### PR DESCRIPTION
Right now this repo won't build in this branch (or the 4.4.3.Final tag), because it points to the snapshot version of the parent pom, which is now gone - Nick released the parent pom.