### PR TITLE
Clean code during code review of JBIDE-24029

### DIFF
--- a/jmx/plugins/org.jboss.tools.jmx.ui/plugin.xml
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/plugin.xml
@@ -174,14 +174,6 @@
             visible="false"
             id="org.jboss.tools.jmx.ui.MBeanActionSet">
            <action
-               id="openMBean"
-               class="org.jboss.tools.jmx.ui.internal.actions.OpenMBeanAction"
-               definitionId="org.jboss.tools.jmx.ui.navigate.open.mbean"
-               label="%OpenMBeanAction.label"
-               menubarPath="navigate/open.ext2"
-               tooltip="%OpenMBeanAction.tooltip">
-         </action>
-           <action
                  class="org.jboss.tools.jmx.ui.internal.actions.RefreshAction"
                  definitionId="org.jboss.tools.jmx.ui.navigate.refresh"
                  id="refresh"
@@ -312,9 +304,7 @@
             location="BOTTOM_RIGHT"
             state="true">
          <enablement>
-            <or>
-               <objectClass name="org.jboss.tools.jmx.core.IConnectionWrapper"/>
-            </or>
+             <objectClass name="org.jboss.tools.jmx.core.IConnectionWrapper"/>
          </enablement>
       </decorator>
    </extension>

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/UIExtensionManager.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/UIExtensionManager.java
@@ -11,7 +11,6 @@
 package org.jboss.tools.jmx.ui;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 
 import org.eclipse.core.runtime.CoreException;
@@ -58,7 +57,7 @@ public class UIExtensionManager {
 			if( imageDescriptor == null ) {
 				IStatus s = new Status(IStatus.WARNING, JMXUIActivator.PLUGIN_ID, 
 						NLS.bind(Messages.JMXUIImageDescriptorNotFound, icon, pluginName));
-				JMXUIActivator.getDefault().log(s);
+				JMXUIActivator.log(s);
 			}
 		}
 		public String getId() {

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/actions/ConnectDebuggerAction.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/actions/ConnectDebuggerAction.java
@@ -61,7 +61,7 @@ public class ConnectDebuggerAction extends Action {
 				}
 				
 				ILaunchConfiguration config = RemoteDebugActivator.createOrGetDefaultLaunchConfiguration(
-						new Integer(con.getDebugPort()).toString(), 
+						Integer.toString(con.getDebugPort()),
 						con.getDebugHost(), jp, (IJavaProject[]) javaProjects.toArray(new IJavaProject[javaProjects.size()]));
 				DebugUITools.launch(config, ILaunchManager.DEBUG_MODE);
 			} catch(CoreException ce) {
@@ -69,7 +69,7 @@ public class ConnectDebuggerAction extends Action {
 			}
 		} else {
 			// We have a null main class, it might be suspended
-			RemoteDebugUIActivator.getDefault().openLaunchDebuggerDialog();
+			RemoteDebugUIActivator.openLaunchDebuggerDialog();
 		}
 	}
 	

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/actions/NewConnectionAction.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/actions/NewConnectionAction.java
@@ -15,7 +15,6 @@ import org.eclipse.jface.action.Action;
 import org.eclipse.jface.wizard.IWizard;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/adapters/MBeanOperationInfoPropertySourceAdapter.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/adapters/MBeanOperationInfoPropertySourceAdapter.java
@@ -14,7 +14,6 @@ import java.util.List;
 import javax.management.MBeanOperationInfo;
 import javax.management.MBeanParameterInfo;
 
-
 import org.eclipse.ui.views.properties.IPropertyDescriptor;
 import org.eclipse.ui.views.properties.IPropertySource;
 import org.eclipse.ui.views.properties.PropertyDescriptor;

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/controls/AbstractTabularControlFactory.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/controls/AbstractTabularControlFactory.java
@@ -18,7 +18,6 @@ import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Decorations;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Menu;
@@ -29,7 +28,7 @@ import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.jboss.tools.jmx.ui.extensions.IAttributeControlFactory;
 import org.jboss.tools.jmx.ui.extensions.IWritableAttributeHandler;
-import org.jboss.tools.jmx.ui.internal.StringUtils;
+import org.jboss.tools.jmx.core.util.StringUtils;
 
 public abstract class AbstractTabularControlFactory 
 		implements IAttributeControlFactory {

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/controls/ArrayControlFactory.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/controls/ArrayControlFactory.java
@@ -19,7 +19,7 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.jboss.tools.jmx.ui.Messages;
-import org.jboss.tools.jmx.ui.internal.StringUtils;
+import org.jboss.tools.jmx.core.util.StringUtils;
 
 public class ArrayControlFactory extends AbstractTabularControlFactory {
 

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/controls/CollectionControlFactory.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/controls/CollectionControlFactory.java
@@ -19,12 +19,11 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.jboss.tools.jmx.ui.Messages;
-import org.jboss.tools.jmx.ui.internal.StringUtils;
+import org.jboss.tools.jmx.core.util.StringUtils;
 
 public class CollectionControlFactory extends AbstractTabularControlFactory {
 
 	@Override
-	@SuppressWarnings("unchecked")
 	protected void fillTable(final Table table, final Object value) {
         TableColumn columnName = new TableColumn(table, SWT.NONE);
         columnName.setText(Messages.name);

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/controls/CompositeDataControlFactory.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/controls/CompositeDataControlFactory.java
@@ -19,7 +19,7 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.jboss.tools.jmx.ui.Messages;
-import org.jboss.tools.jmx.ui.internal.StringUtils;
+import org.jboss.tools.jmx.core.util.StringUtils;
 
 public class CompositeDataControlFactory extends AbstractTabularControlFactory {
 

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/controls/MapControlFactory.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/controls/MapControlFactory.java
@@ -19,12 +19,11 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.jboss.tools.jmx.ui.Messages;
-import org.jboss.tools.jmx.ui.internal.StringUtils;
+import org.jboss.tools.jmx.core.util.StringUtils;
 
 public class MapControlFactory extends AbstractTabularControlFactory {
 
 	@Override
-	@SuppressWarnings("unchecked")
 	protected void fillTable(final Table table, final Object value) {
         TableColumn keyColumn = new TableColumn(table, SWT.NONE);
         keyColumn.setText(Messages.key);

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/controls/TabularDataControlFactory.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/controls/TabularDataControlFactory.java
@@ -21,12 +21,11 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
-import org.jboss.tools.jmx.ui.internal.StringUtils;
+import org.jboss.tools.jmx.core.util.StringUtils;
 
 public class TabularDataControlFactory extends AbstractTabularControlFactory {
 
 	@Override
-	@SuppressWarnings("unchecked")
 	protected void fillTable(final Table table, final Object value) {
 		TabularData data = (TabularData) value;
 		

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/editors/AttributeDetails.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/editors/AttributeDetails.java
@@ -48,7 +48,7 @@ import org.jboss.tools.jmx.ui.JMXUIActivator;
 import org.jboss.tools.jmx.ui.Messages;
 import org.jboss.tools.jmx.ui.extensions.IWritableAttributeHandler;
 import org.jboss.tools.jmx.ui.internal.JMXImages;
-import org.jboss.tools.jmx.ui.internal.StringUtils;
+import org.jboss.tools.jmx.core.util.StringUtils;
 import org.jboss.tools.jmx.ui.internal.controls.AttributeControlFactory;
 
 public class AttributeDetails extends AbstractFormPart implements IDetailsPage {

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/editors/NotificationsPage.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/editors/NotificationsPage.java
@@ -82,8 +82,7 @@ public class NotificationsPage extends FormPage {
 
     private NotificationListener listener;
 
-    @SuppressWarnings("unchecked")
-    private List notifications = new ArrayList();
+    private List<Notification> notifications = new ArrayList<Notification>();
 
     private TableViewer viewer;
 
@@ -157,9 +156,8 @@ public class NotificationsPage extends FormPage {
         viewer.setLabelProvider(new NotificationLabelProvider());
         viewer.setContentProvider(new IStructuredContentProvider() {
 
-            @SuppressWarnings("unchecked")
             public Object[] getElements(Object inputElement) {
-                return (Notification[]) notifications
+                return notifications
                         .toArray(new Notification[notifications.size()]);
             }
 
@@ -173,7 +171,6 @@ public class NotificationsPage extends FormPage {
         });
         viewer.setInput(notifications);
         listener = new NotificationListener() {
-            @SuppressWarnings("unchecked")
             public void handleNotification(final Notification notification,
                     Object handback) {
                 // add notification at the head so that the more recent

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/editors/OperationDetails.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/editors/OperationDetails.java
@@ -42,7 +42,7 @@ import org.jboss.tools.jmx.core.MBeanOperationInfoWrapper;
 import org.jboss.tools.jmx.ui.JMXUIActivator;
 import org.jboss.tools.jmx.ui.Messages;
 import org.jboss.tools.jmx.ui.internal.MBeanUtils;
-import org.jboss.tools.jmx.ui.internal.StringUtils;
+import org.jboss.tools.jmx.core.util.StringUtils;
 import org.jboss.tools.jmx.ui.internal.dialogs.OperationInvocationResultDialog;
 
 public class OperationDetails extends AbstractFormPart implements IDetailsPage {
@@ -161,7 +161,7 @@ public class OperationDetails extends AbstractFormPart implements IDetailsPage {
         if (params.length > 0) {
             textParams = new Text[params.length];
             for (int j = 0; j < params.length; j++) {
-            	Label buffer = new Label(operationComposite, SWT.NONE);
+            	new Label(operationComposite, SWT.NONE);
                 MBeanParameterInfo param = params[j];
                 textParams[j] = new Text(operationComposite, SWT.SINGLE | SWT.BORDER);
                 textParams[j].setText(StringUtils.toString(param.getType()));
@@ -178,7 +178,7 @@ public class OperationDetails extends AbstractFormPart implements IDetailsPage {
                 GridData gd = new GridData(SWT.FILL, SWT.BOTTOM, false, true);
                 gd.horizontalSpan = 2;
                 gd.widthHint = 250;
-                paramDesc.setLayoutData(gd);;
+                paramDesc.setLayoutData(gd);
             }
         }
         Label rightParenthesis = toolkit.createLabel(operationComposite, ")"); //$NON-NLS-1$

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/tables/AttributesViewerSorter.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/tables/AttributesViewerSorter.java
@@ -20,7 +20,7 @@ class AttributesViewerSorter extends ViewerSorter {
     int direction, index;
 
     protected AttributesViewerSorter(int direction, int index) {
-        this.direction = (direction == SWT.UP ? -1 : 1);
+        this.direction = direction == SWT.UP ? -1 : 1;
         this.index = index;
     }
 

--- a/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/tables/MBeanOperationsTable.java
+++ b/jmx/plugins/org.jboss.tools.jmx.ui/src/org/jboss/tools/jmx/ui/internal/tables/MBeanOperationsTable.java
@@ -32,7 +32,7 @@ import org.jboss.tools.jmx.core.MBeanInfoWrapper;
 import org.jboss.tools.jmx.core.MBeanOperationInfoWrapper;
 import org.jboss.tools.jmx.ui.Messages;
 import org.jboss.tools.jmx.ui.internal.JMXImages;
-import org.jboss.tools.jmx.ui.internal.StringUtils;
+import org.jboss.tools.jmx.core.util.StringUtils;
 
 public class MBeanOperationsTable {
 


### PR DESCRIPTION
- use static access
- use Integer.toString to avoid instantiation of an Object
- remove unused import
- remove uneccessary suppress warning
- remove action which has no more corresponding class available
- fix extension point enablement with a single 'or'
- remove used of deprecated StringUtils
- use genericity