### PR TITLE
Update supported server versions in server requirements

### DIFF
--- a/as/test-framework/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerReqType.java
+++ b/as/test-framework/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerReqType.java
@@ -84,9 +84,18 @@ public enum ServerReqType {
 	 */
 	EAP6_1plus(ServerReqFamily.EAP, "6.1+"),
 	/**
-	 * JBoss Enterprise Application Platform 6.1+
+	 * JBoss Enterprise Application Platform 7.x - Deprecated
 	 */
+	@Deprecated
 	EAP7x(ServerReqFamily.EAP, "7.x"),
+	/**
+	 * JBoss Enterprise Application Platform 7.0
+	 */
+	EAP7_0(ServerReqFamily.EAP, "7.0"),
+	/**
+	 * JBoss Enterprise Application Platform 7.1
+	 */
+	EAP7_1(ServerReqFamily.EAP, "7.1"),
 	
 	/**
 	 * WildFly
@@ -106,9 +115,13 @@ public enum ServerReqType {
 	/**
 	 * WildFly 10.x
 	 */
-	WILDFLY10x(ServerReqFamily.WILDFLY, "10.x");
+	WILDFLY10x(ServerReqFamily.WILDFLY, "10.x"),
 
-
+	/**
+	 * WildFly 11
+	 */
+	WILDFLY11(ServerReqFamily.WILDFLY, "11");
+	
 	private String version;
 	
 	private ServerReqFamily family;

--- a/as/test-framework/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerRequirement.java
+++ b/as/test-framework/org.jboss.ide.eclipse.as.reddeer/src/org/jboss/ide/eclipse/as/reddeer/server/requirement/ServerRequirement.java
@@ -151,6 +151,7 @@ public class ServerRequirement extends ServerReqBase implements Requirement<JBos
 					serverTypeLabelText = label+" "+ version;
 				}
 			}
+			// condition should be removed after deprecated ServerReqType.EAP7x is removed
 			if(FamilyEAP.class.equals(config.getServerFamily().getClass())){
 				String label = config.getServerFamily().getLabel();
 				String version = config.getServerFamily().getVersion();


### PR DESCRIPTION
   - deprecated EAP7x (not breaking iTests compilation)
   - add EAP7_0
   - add EAP7_1
   - add WILDFLY_11