### PR TITLE
JBIDE-24668 add enablements for...

### DIFF
--- a/wtp/plugins/org.jboss.tools.wtp.server.launchbar/plugin.xml
+++ b/wtp/plugins/org.jboss.tools.wtp.server.launchbar/plugin.xml
@@ -12,11 +12,17 @@
             class="org.jboss.tools.wtp.server.launchbar.ModuleDescriptorType"
             id="org.jboss.tools.wtp.server.launchbar.ModuleDescriptorType"
             priority="5">
+            <enablement>
+                <instanceof value="org.eclipse.debug.core.ILaunchConfiguration">
+                </instanceof>
+            </enablement>
       </descriptorType>
       <configProvider
             descriptorType="org.jboss.tools.wtp.server.launchbar.ModuleDescriptorType"
             class="org.jboss.tools.wtp.server.launchbar.ModuleLaunchConfigurationProvider"
             priority="1">
+            <enablement>
+            </enablement>
       </configProvider>
    </extension>
    <extension


### PR DESCRIPTION
JBIDE-24668 add enablements for descriptorType org.jboss.tools.wtp.server.launchbar.ModuleDescriptorType and configProvider org.jboss.tools.wtp.server.launchbar.ModuleLaunchConfigurationProvider to suppress warnings

Signed-off-by: nickboldt <nboldt@redhat.com>