### PR TITLE
JBIDE-24763 use 1/4 less disk when running itests

### DIFF
--- a/as/itests/pom.xml
+++ b/as/itests/pom.xml
@@ -108,10 +108,31 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 			</activation>
 			<properties>
 				<!-- property will be fixed when ../../tests folder exists, so that we can reuse it for downloaded requirements -->
-				<requirementsDirectory>${project.build.directory}/../../target/requirements</requirementsDirectory>
+				<requirementsDirectory>${basedir}/../target/requirements</requirementsDirectory>
 			</properties>
 			<build>
 				<plugins>
+					<plugin>
+						<artifactId>maven-clean-plugin</artifactId>
+						<version>3.0.0</version>
+						<executions>
+							<execution>
+								<id>clean-requirementsDirectory</id>
+								<phase>clean</phase>
+								<goals>
+									<goal>clean</goal>
+								</goals>
+								<configuration>
+									<filesets>
+										<fileset>
+											<directory>${basedir}/../target/requirements</directory>
+											<followSymlinks>false</followSymlinks>
+										</fileset>
+									</filesets>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-dependency-plugin</artifactId>

--- a/as/itests/pom.xml
+++ b/as/itests/pom.xml
@@ -64,6 +64,47 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	</build>
 		
 	<profiles>
+
+		<!-- this profile will be activated automatically when ../../tests folder exists, so that we can reuse it for downloaded requirements -->
+		<profile>
+			<id>fix-requirementsDirectory</id>
+			<activation>
+				<file>
+					<exists>../../itests</exists>
+				</file>
+			</activation>
+			<properties>
+				<requirementsDirectory>${project.build.directory}/../../target/requirements</requirementsDirectory>
+			</properties>
+		</profile>
+		<!-- this profile can be used to simply display the values of project.build.directory and requirementsDirectory -->
+		<profile>
+			<id>verbose-requirementsDirectory</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-antrun-plugin</artifactId>
+						<version>${maven.antrun.plugin.version}</version>
+						<executions>
+							<execution>
+								<phase>verify</phase>
+								<goals>
+									<goal>run</goal>
+								</goals>
+								<configuration>
+									<quiet>true</quiet>
+									<tasks>
+										<echo>project.build.directory = ${project.build.directory}</echo>
+										<echo>requirementsDirectory = ${requirementsDirectory}</echo>
+									</tasks>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 		<profile>
 			<id>download-all-runtimes</id>
 			<!-- Do not download all runtimes if only testing one runtime - eap compatibility testing -->

--- a/as/itests/pom.xml
+++ b/as/itests/pom.xml
@@ -65,18 +65,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		
 	<profiles>
 
-		<!-- this profile will be activated automatically when ../../tests folder exists, so that we can reuse it for downloaded requirements -->
-		<profile>
-			<id>fix-requirementsDirectory</id>
-			<activation>
-				<file>
-					<exists>../../itests</exists>
-				</file>
-			</activation>
-			<properties>
-				<requirementsDirectory>${project.build.directory}/../../target/requirements</requirementsDirectory>
-			</properties>
-		</profile>
 		<!-- this profile can be used to simply display the values of project.build.directory and requirementsDirectory -->
 		<profile>
 			<id>verbose-requirementsDirectory</id>
@@ -107,13 +95,21 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		</profile>
 		<profile>
 			<id>download-all-runtimes</id>
-			<!-- Do not download all runtimes if only testing one runtime - eap compatibility testing -->
 			<activation>
+				<!-- JBIDE-24763 only download everything if we're running in a plugin folder, not the itests/ folder. -->
+				<file>
+					<exists>../../itests</exists>
+				</file>
+				<!-- Do not download all runtimes if only testing one runtime - eap compatibility testing -->
 				<property>
 					<name>test.profile</name>
 					<value>!eap7x-compatibility</value>
 				</property>
 			</activation>
+			<properties>
+				<!-- property will be fixed when ../../tests folder exists, so that we can reuse it for downloaded requirements -->
+				<requirementsDirectory>${project.build.directory}/../../target/requirements</requirementsDirectory>
+			</properties>
 			<build>
 				<plugins>
 					<plugin>


### PR DESCRIPTION
JBIDE-24763 instead of 4 copies of target/requirements/ taking up 1.9G - 3.5G of disk, use one shared folder under itests/target/requirements

Signed-off-by: nickboldt <nboldt@redhat.com>