### PR TITLE
Revert "OSFUSE-548 - prelim work"

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/tools/as/core/server/controllable/subsystems/internal/StandardFileSystemPublishController.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/tools/as/core/server/controllable/subsystems/internal/StandardFileSystemPublishController.java
@@ -30,7 +30,6 @@ import org.eclipse.osgi.util.NLS;
 import org.eclipse.wst.server.core.IModule;
 import org.eclipse.wst.server.core.IServer;
 import org.eclipse.wst.server.core.internal.Server;
-import org.eclipse.wst.server.core.model.IModuleFolder;
 import org.eclipse.wst.server.core.model.IModuleResource;
 import org.eclipse.wst.server.core.model.IModuleResourceDelta;
 import org.jboss.ide.eclipse.as.core.JBossServerCorePlugin;
@@ -319,7 +318,7 @@ public class StandardFileSystemPublishController extends AbstractSubsystemContro
 		 * 
 		 * private int handleBinaryModule(IModule[] module, IPath archiveDestination) throws CoreException
 		 */
-		boolean isBinaryObject = treatAsBinaryModule(module);
+		boolean isBinaryObject = ServerModelUtilities.isBinaryModule(module);
 		Trace.trace(Trace.STRING_FINER, "   Module " + module[module.length-1].getName() + " is binary? " + isBinaryObject); //$NON-NLS-1$ //$NON-NLS-2$
 
 		boolean serverPrefersZipped = prefersZipped();
@@ -408,14 +407,6 @@ public class StandardFileSystemPublishController extends AbstractSubsystemContro
 		return acc == null || acc.isOK() ? IServer.PUBLISH_STATE_NONE : IServer.PUBLISH_STATE_UNKNOWN;
 	}
 	
-	protected boolean treatAsBinaryModule(IModule[] module) {
-		return true; // isBinaryModule(module);		
-	}
-
-	protected boolean isBinaryModule(IModule[] module) {
-		return ServerModelUtilities.isBinaryModule(module);		
-	}
-
 	/*
 	 * Binary modules are non-standard modules that WTP has created, and so must
 	 * be handled. Your typical module will follow servertools API, and, the


### PR DESCRIPTION
This commit is changing the behavior by always returning that it is a
binaryObject.

This reverts commit 87aab64658419b2d52c5c6ce1f9b72af34a160b9.