### PR TITLE
JBIDE-25591 - restrict earlier runtimes from using java9 bc they all fail

### DIFF
--- a/as/features/org.jboss.ide.eclipse.as.archives.integration.feature/feature.xml
+++ b/as/features/org.jboss.ide.eclipse.as.archives.integration.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.ide.eclipse.as.archives.integration.feature"
       label="%featureName"
-      version="3.5.2.qualifier"
+      version="3.5.3.qualifier"
       provider-name="%providerName"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0"

--- a/as/features/org.jboss.ide.eclipse.as.archives.integration.feature/pom.xml
+++ b/as/features/org.jboss.ide.eclipse.as.archives.integration.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>features</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.features</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.archives.integration.feature</artifactId> 

--- a/as/features/org.jboss.ide.eclipse.as.feature/feature.xml
+++ b/as/features/org.jboss.ide.eclipse.as.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.ide.eclipse.as.feature"
       label="%featureName"
-      version="3.5.2.qualifier"
+      version="3.5.3.qualifier"
       provider-name="%providerName"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0"

--- a/as/features/org.jboss.ide.eclipse.as.feature/pom.xml
+++ b/as/features/org.jboss.ide.eclipse.as.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>features</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.features</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.feature</artifactId> 

--- a/as/features/org.jboss.ide.eclipse.as.jmx.integration.feature/feature.xml
+++ b/as/features/org.jboss.ide.eclipse.as.jmx.integration.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.ide.eclipse.as.jmx.integration.feature"
       label="%featureName"
-      version="3.5.2.qualifier"
+      version="3.5.3.qualifier"
       provider-name="%providerName"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0"

--- a/as/features/org.jboss.ide.eclipse.as.jmx.integration.feature/pom.xml
+++ b/as/features/org.jboss.ide.eclipse.as.jmx.integration.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>features</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.features</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.jmx.integration.feature</artifactId> 

--- a/as/features/org.jboss.ide.eclipse.as.server.rse.integration.feature/feature.xml
+++ b/as/features/org.jboss.ide.eclipse.as.server.rse.integration.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.ide.eclipse.as.server.rse.integration.feature"
       label="%featureName"
-      version="3.5.2.qualifier"
+      version="3.5.3.qualifier"
       provider-name="%providerName"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0"

--- a/as/features/org.jboss.ide.eclipse.as.server.rse.integration.feature/pom.xml
+++ b/as/features/org.jboss.ide.eclipse.as.server.rse.integration.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>features</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.features</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.server.rse.integration.feature</artifactId> 

--- a/as/features/org.jboss.ide.eclipse.as.serverAdapter.wtp.feature/feature.xml
+++ b/as/features/org.jboss.ide.eclipse.as.serverAdapter.wtp.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature 
    id="org.jboss.ide.eclipse.as.serverAdapter.wtp.feature" 
    label="%featureName" 
-   version="3.5.2.qualifier" 
+   version="3.5.3.qualifier" 
    license-feature="org.jboss.tools.foundation.license.feature"
    license-feature-version="0.0.0"
    provider-name="%providerName">

--- a/as/features/org.jboss.ide.eclipse.as.serverAdapter.wtp.feature/pom.xml
+++ b/as/features/org.jboss.ide.eclipse.as.serverAdapter.wtp.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>features</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.features</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.serverAdapter.wtp.feature</artifactId> 

--- a/as/features/org.jboss.ide.eclipse.as.test.feature/feature.xml
+++ b/as/features/org.jboss.ide.eclipse.as.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature 
    id="org.jboss.ide.eclipse.as.test.feature" 
    label="%featureName" 
-   version="3.5.2.qualifier" 
+   version="3.5.3.qualifier" 
    license-feature="org.jboss.tools.foundation.license.feature"
    license-feature-version="0.0.0"
    provider-name="%providerName">

--- a/as/features/org.jboss.ide.eclipse.as.test.feature/pom.xml
+++ b/as/features/org.jboss.ide.eclipse.as.test.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>features</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.features</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.test.feature</artifactId> 

--- a/as/features/pom.xml
+++ b/as/features/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>as</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as</groupId>
 	<artifactId>features</artifactId>

--- a/as/itests/org.jboss.tools.as.itests/META-INF/MANIFEST.MF
+++ b/as/itests/org.jboss.tools.as.itests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %BundleName
 Bundle-Vendor: %BundleVendor
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.jboss.tools.as.itests
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.jboss.ide.eclipse.as.core;bundle-version="[3.1.1,4.0.0)",
  org.junit;bundle-version="[4.8.1,5.0.0)",

--- a/as/itests/org.jboss.tools.as.itests/pom.xml
+++ b/as/itests/org.jboss.tools.as.itests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>itests</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.itests</groupId>
 	<artifactId>org.jboss.tools.as.itests</artifactId> 

--- a/as/itests/org.jboss.tools.as.management.itests/META-INF/MANIFEST.MF
+++ b/as/itests/org.jboss.tools.as.management.itests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %BundleName
 Bundle-Vendor: %BundleVendor
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.jboss.tools.as.management.itests
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.jboss.ide.eclipse.as.core;bundle-version="[3.0.0,4.0.0)",
  org.junit;bundle-version="[4.8.1,5.0.0)",

--- a/as/itests/org.jboss.tools.as.management.itests/pom.xml
+++ b/as/itests/org.jboss.tools.as.management.itests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>itests</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.itests</groupId>
 	<artifactId>org.jboss.tools.as.management.itests</artifactId> 

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/META-INF/MANIFEST.MF
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: AS Runtime UI Bot Tests
 Bundle-SymbolicName: org.jboss.tools.as.ui.bot.itests
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-ActivationPolicy: lazy
 Eclipse-BundleShape: jar
 Bundle-Localization: plugin

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/pom.xml
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>itests</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.itests</groupId>
 	<artifactId>org.jboss.tools.as.ui.bot.itests</artifactId>

--- a/as/itests/pom.xml
+++ b/as/itests/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>as</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as</groupId>
 	<artifactId>itests</artifactId>

--- a/as/plugins/org.jboss.ide.eclipse.archives.webtools/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.archives.webtools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.ide.eclipse.archives.webtools;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.archives.webtools.IntegrationPlugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.eclipse.core.runtime;bundle-version="3.7.0",

--- a/as/plugins/org.jboss.ide.eclipse.archives.webtools/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.archives.webtools/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.archives.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.archives.webtools</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.classpath.core/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.classpath.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.classpath.core;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.classpath.core.ClasspathCorePlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.jdt.core;bundle-version="3.7.0",

--- a/as/plugins/org.jboss.ide.eclipse.as.classpath.core/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.classpath.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.classpath.core</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.classpath.ui/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.classpath.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.classpath.ui;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.classpath.ui.ClasspathUIPlugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.eclipse.core.runtime;bundle-version="3.7.0",

--- a/as/plugins/org.jboss.ide.eclipse.as.classpath.ui/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.classpath.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.classpath.ui</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.core/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.core;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.core.JBossServerCorePlugin
 Bundle-Localization: plugin
 Require-Bundle: org.apache.ant;bundle-version="1.7.1",

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossEAP61ExtendedProperties.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossEAP61ExtendedProperties.java
@@ -16,7 +16,7 @@ import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 import org.jboss.ide.eclipse.as.core.server.IDefaultLaunchArguments;
 import org.jboss.ide.eclipse.as.management.core.IJBoss7ManagerService;
 
-public class JBossEAP61ExtendedProperties extends JBossEAP60ExtendedProperties {
+public class JBossEAP61ExtendedProperties extends JBossAS710ExtendedProperties {
 	public JBossEAP61ExtendedProperties(IAdaptable obj) {
 		super(obj);
 	}
@@ -39,10 +39,17 @@ public class JBossEAP61ExtendedProperties extends JBossEAP60ExtendedProperties {
 		return IJBoss7ManagerService.EAP_VERSION_61PLUS;
 	}
 
-	
 	@Override
 	public boolean allowExplodedModulesInWarLibs() {
 		return true;
+	}
+
+	public boolean requiresJDK() {
+		return true;
+	}
+	
+	public boolean allowExplodedModulesInEars() {
+		return allowExplodedModulesInWarLibs();
 	}
 
 }

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossEAP61ExtendedProperties.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossEAP61ExtendedProperties.java
@@ -44,10 +44,12 @@ public class JBossEAP61ExtendedProperties extends JBossAS710ExtendedProperties {
 		return true;
 	}
 
+	@Override
 	public boolean requiresJDK() {
 		return true;
 	}
 	
+	@Override
 	public boolean allowExplodedModulesInEars() {
 		return allowExplodedModulesInWarLibs();
 	}

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossEAP70ExtendedProperties.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossEAP70ExtendedProperties.java
@@ -14,8 +14,9 @@ import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 import org.jboss.ide.eclipse.as.core.server.IDefaultLaunchArguments;
+import org.jboss.ide.eclipse.as.management.core.IJBoss7ManagerService;
 
-public class JBossEAP70ExtendedProperties extends Wildfly90ExtendedProperties {
+public class JBossEAP70ExtendedProperties extends JBossAS710ExtendedProperties {
 	public JBossEAP70ExtendedProperties(IAdaptable obj) {
 		super(obj);
 	}
@@ -35,5 +36,28 @@ public class JBossEAP70ExtendedProperties extends Wildfly90ExtendedProperties {
 		if( server != null)
 			return new JBossEAP70DefaultLaunchArguments(server);
 		return new JBossEAP70DefaultLaunchArguments(runtime);
+	}
+
+	@Override
+	public String getJMXUrl() {
+			return getJMXUrl(9990, "service:jmx:remote+http"); //$NON-NLS-1$
+	}
+	
+	@Override
+	public boolean requiresJDK() {
+		return true;
+	}
+	@Override
+	public String getManagerServiceId() {
+		return IJBoss7ManagerService.WILDFLY_VERSION_900;
+	}
+	
+	@Override
+	public boolean allowExplodedModulesInWarLibs() {
+		return true;
+	}
+	
+	public boolean allowExplodedModulesInEars() {
+		return true;
 	}
 }

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossEAP70ExtendedProperties.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossEAP70ExtendedProperties.java
@@ -57,6 +57,7 @@ public class JBossEAP70ExtendedProperties extends JBossAS710ExtendedProperties {
 		return true;
 	}
 	
+	@Override
 	public boolean allowExplodedModulesInEars() {
 		return true;
 	}

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossEAP71ExtendedProperties.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossEAP71ExtendedProperties.java
@@ -16,7 +16,7 @@ import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 import org.jboss.ide.eclipse.as.core.server.IDefaultLaunchArguments;
 import org.jboss.ide.eclipse.as.management.core.IJBoss7ManagerService;
 
-public class JBossEAP71ExtendedProperties extends Wildfly90ExtendedProperties {
+public class JBossEAP71ExtendedProperties extends JBossAS710ExtendedProperties {
 	public JBossEAP71ExtendedProperties(IAdaptable obj) {
 		super(obj);
 	}
@@ -41,4 +41,30 @@ public class JBossEAP71ExtendedProperties extends Wildfly90ExtendedProperties {
 			return new Wildfly100DefaultLaunchArguments(server);
 		return new Wildfly100DefaultLaunchArguments(runtime);
 	}
+	@Override
+	public String getJMXUrl() {
+			return getJMXUrl(9990, "service:jmx:remote+http"); //$NON-NLS-1$
+	}
+	
+	@Override
+	public boolean requiresJDK() {
+		return true;
+	}
+	
+	@Override
+	public boolean allowExplodedModulesInWarLibs() {
+		return true;
+	}
+	@Override
+	public boolean allowExplodedModulesInEars() {
+		return true;
+	}
+	/**
+	 * EAP 7.1 appears to work through java 9 to varying degrees
+	 */
+	@Override
+	public IExecutionEnvironment getMaximumExecutionEnvironment() {
+		return null;
+	}
+
 }

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossExtendedProperties.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossExtendedProperties.java
@@ -212,11 +212,11 @@ public class JBossExtendedProperties extends ServerExtendedProperties {
 		// NEW_SERVER_ADAPTER  Subclasses override this
 		return getDefaultExecutionEnvironment();
 	}
-	
+
 	// Return an exec-env or null if it can run on any higher exec-env. 
 	public IExecutionEnvironment getMaximumExecutionEnvironment() {
 		// NEW_SERVER_ADAPTER  Subclasses override this
-		return null;
+		return JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("JavaSE-1.8"); //$NON-NLS-1$
 	}
 
 	/**

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/Wildfly100ExtendedProperties.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/Wildfly100ExtendedProperties.java
@@ -56,6 +56,7 @@ public class Wildfly100ExtendedProperties extends JBossAS710ExtendedProperties {
 		return true;
 	}
 	
+	@Override
 	public boolean allowExplodedModulesInEars() {
 		return true;
 	}

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/Wildfly100ExtendedProperties.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/Wildfly100ExtendedProperties.java
@@ -14,8 +14,9 @@ import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 import org.jboss.ide.eclipse.as.core.server.IDefaultLaunchArguments;
+import org.jboss.ide.eclipse.as.management.core.IJBoss7ManagerService;
 
-public class Wildfly100ExtendedProperties extends Wildfly90ExtendedProperties {
+public class Wildfly100ExtendedProperties extends JBossAS710ExtendedProperties {
 	public Wildfly100ExtendedProperties(IAdaptable obj) {
 		super(obj);
 	}
@@ -29,11 +30,33 @@ public class Wildfly100ExtendedProperties extends Wildfly90ExtendedProperties {
 		return JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("JavaSE-1.8"); //$NON-NLS-1$
 	}
 	
-
 	@Override
 	public IDefaultLaunchArguments getDefaultLaunchArguments() {
 		if( server != null)
 			return new Wildfly100DefaultLaunchArguments(server);
 		return new Wildfly100DefaultLaunchArguments(runtime);
+	}
+	
+	@Override
+	public String getJMXUrl() {
+			return getJMXUrl(9990, "service:jmx:remote+http"); //$NON-NLS-1$
+	}
+	
+	@Override
+	public boolean requiresJDK() {
+		return true;
+	}
+	@Override
+	public String getManagerServiceId() {
+		return IJBoss7ManagerService.WILDFLY_VERSION_900;
+	}
+	
+	@Override
+	public boolean allowExplodedModulesInWarLibs() {
+		return true;
+	}
+	
+	public boolean allowExplodedModulesInEars() {
+		return true;
 	}
 }

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/Wildfly110ExtendedProperties.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/Wildfly110ExtendedProperties.java
@@ -11,9 +11,12 @@
 package org.jboss.ide.eclipse.as.core.server.internal.extendedproperties;
 
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.jdt.launching.JavaRuntime;
+import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
+import org.jboss.ide.eclipse.as.core.server.IDefaultLaunchArguments;
 import org.jboss.ide.eclipse.as.management.core.IJBoss7ManagerService;
 
-public class Wildfly110ExtendedProperties extends Wildfly100ExtendedProperties {
+public class Wildfly110ExtendedProperties extends JBossAS710ExtendedProperties {
 	public Wildfly110ExtendedProperties(IAdaptable obj) {
 		super(obj);
 	}
@@ -27,4 +30,44 @@ public class Wildfly110ExtendedProperties extends Wildfly100ExtendedProperties {
 		return IJBoss7ManagerService.WILDFLY_VERSION_110;
 	}
 
+	@Override
+	public IExecutionEnvironment getDefaultExecutionEnvironment() {
+		return JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("JavaSE-1.8"); //$NON-NLS-1$
+	}
+	
+	@Override
+	public IDefaultLaunchArguments getDefaultLaunchArguments() {
+		if( server != null)
+			return new Wildfly100DefaultLaunchArguments(server);
+		return new Wildfly100DefaultLaunchArguments(runtime);
+	}
+
+	@Override
+	public String getJMXUrl() {
+			return getJMXUrl(9990, "service:jmx:remote+http"); //$NON-NLS-1$
+	}
+
+	@Override
+	public boolean requiresJDK() {
+		return true;
+	}
+
+	@Override
+	public boolean allowExplodedModulesInWarLibs() {
+		return true;
+	}
+	
+	@Override
+	public boolean allowExplodedModulesInEars() {
+		return true;
+	}
+	
+
+	/**
+	 * Wildfly 11 appears to work through java 9 to varying degrees
+	 */
+	@Override
+	public IExecutionEnvironment getMaximumExecutionEnvironment() {
+		return null;
+	}
 }

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/Wildfly90ExtendedProperties.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/Wildfly90ExtendedProperties.java
@@ -56,6 +56,7 @@ public class Wildfly90ExtendedProperties extends JBossAS710ExtendedProperties {
 		return true;
 	}
 	
+	@Override
 	public boolean allowExplodedModulesInEars() {
 		return true;
 	}

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/Wildfly90ExtendedProperties.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/Wildfly90ExtendedProperties.java
@@ -13,8 +13,10 @@ package org.jboss.ide.eclipse.as.core.server.internal.extendedproperties;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
+import org.jboss.ide.eclipse.as.core.server.IDefaultLaunchArguments;
+import org.jboss.ide.eclipse.as.management.core.IJBoss7ManagerService;
 
-public class Wildfly90ExtendedProperties extends Wildfly80ExtendedProperties {
+public class Wildfly90ExtendedProperties extends JBossAS710ExtendedProperties {
 	public Wildfly90ExtendedProperties(IAdaptable obj) {
 		super(obj);
 	}
@@ -31,5 +33,30 @@ public class Wildfly90ExtendedProperties extends Wildfly80ExtendedProperties {
 	@Override
 	public IExecutionEnvironment getDefaultExecutionEnvironment() {
 		return JavaRuntime.getExecutionEnvironmentsManager().getEnvironment("JavaSE-1.8"); //$NON-NLS-1$
+	}
+
+	@Override
+	public IDefaultLaunchArguments getDefaultLaunchArguments() {
+		if( server != null)
+			return new Wildfly80DefaultLaunchArguments(server);
+		return new Wildfly80DefaultLaunchArguments(runtime);
+	}
+	
+	@Override
+	public boolean requiresJDK() {
+		return true;
+	}
+	@Override
+	public String getManagerServiceId() {
+		return IJBoss7ManagerService.WILDFLY_VERSION_900;
+	}
+	
+	@Override
+	public boolean allowExplodedModulesInWarLibs() {
+		return true;
+	}
+	
+	public boolean allowExplodedModulesInEars() {
+		return true;
 	}
 }

--- a/as/plugins/org.jboss.ide.eclipse.as.core/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.core</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.dmr/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.dmr/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss AS, WildFly & EAP Server Adapter - Dynamic Model Representation
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.dmr;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.dmr.Activator
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/as/plugins/org.jboss.ide.eclipse.as.dmr/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.dmr/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.dmr</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.doc.user/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.doc.user;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.help;bundle-version="3.5.0"

--- a/as/plugins/org.jboss.ide.eclipse.as.doc.user/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.doc.user/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.docs</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.doc.user</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.jmx.integration/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.jmx.integration/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss AS, WildFly & EAP Server Tools - JMX Integration
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.jmx.integration;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.jmx.integration.Activator
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.eclipse.core.runtime;bundle-version="3.7.0",

--- a/as/plugins/org.jboss.ide.eclipse.as.jmx.integration/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.jmx.integration/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.jmx.integration</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.management.as7/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.management.as7/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss AS7.1 management API
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.management.as7
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.internal.management.as70x.AS70xManagementActivator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",
  org.jboss.ide.eclipse.as.management.core;bundle-version="[3.0.0,4.0.0)"

--- a/as/plugins/org.jboss.ide.eclipse.as.management.as7/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.management.as7/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.management.as7</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.management.core/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.management.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss AS, WildFly & EAP Management Interface Core Plugin
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.management.core
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.management.core.AS7ManagementActivator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.wst.server.core

--- a/as/plugins/org.jboss.ide.eclipse.as.management.core/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.management.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.management.core</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.management.eap61plus/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.management.eap61plus/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss WildFly Management API
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.management.eap61plus
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.internal.management.eap61plus.EAP61PlusManagementActivator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",
  org.jboss.ide.eclipse.as.management.core;bundle-version="[3.0.0,4.0.0)"

--- a/as/plugins/org.jboss.ide.eclipse.as.management.eap61plus/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.management.eap61plus/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.management.eap61plus</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.management.wf11/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.management.wf11/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss WildFly Management API
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.management.wf11
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.internal.management.wf11.WildFly11ManagementActivator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",
  org.jboss.ide.eclipse.as.management.core;bundle-version="[3.0.0,4.0.0)"

--- a/as/plugins/org.jboss.ide.eclipse.as.management.wf11/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.management.wf11/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.management.wf11</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.management.wildfly9/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.management.wildfly9/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss WildFly Management API
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.management.wildfly9
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.internal.management.wildfly9.Wildfly9ManagementActivator
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.7.0,4.0.0)",
  org.jboss.ide.eclipse.as.management.core;bundle-version="[3.0.0,4.0.0)"

--- a/as/plugins/org.jboss.ide.eclipse.as.management.wildfly9/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.management.wildfly9/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.management.wildfly9</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.rse.core/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.rse.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.rse.core;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.rse.core.RSECorePlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.core.resources;bundle-version="3.7.100",

--- a/as/plugins/org.jboss.ide.eclipse.as.rse.core/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.rse.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.rse.core</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.rse.ui/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.rse.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-Vendor: %Bundle-Vendor.0
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.rse.ui;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.rse.ui.RSEUIPlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.ui;bundle-version="3.7.0",

--- a/as/plugins/org.jboss.ide.eclipse.as.rse.ui/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.rse.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.rse.ui</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.ui.mbeans/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui.mbeans/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.ui.mbeans;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.ui.mbeans.Activator
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",

--- a/as/plugins/org.jboss.ide.eclipse.as.ui.mbeans/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui.mbeans/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.ui.mbeans</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.ui;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Localization: plugin
 Require-Bundle: com.ibm.icu;bundle-version="4.2.1",
  org.apache.ant;bundle-version="1.7.1",

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/wizards/JBoss7RuntimeWizardFragment.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/wizards/JBoss7RuntimeWizardFragment.java
@@ -308,21 +308,9 @@ public class JBoss7RuntimeWizardFragment extends JBossRuntimeWizardFragment {
 			return Messages.rwf_nameTextBlank;
 		
 
-		if( jreComposite != null ) {
-			IExecutionEnvironment selectedEnv = jreComposite.getSelectedExecutionEnvironment();
-			IVMInstall install = jreComposite.getSelectedVM();
-			if( install == null ) {
-				// user has selected an exec-env, not a vm
-				if( selectedEnv != null ) {
-					if( selectedEnv.getCompatibleVMs().length == 0 ) {
-						return NLS.bind(Messages.rwf_noValidJRE, selectedEnv.getId());
-					}
-				}
-			}
-		}
-		
-		if( jreComposite != null && jreComposite.getValidJREs().size() == 0 )
-			return NLS.bind(Messages.rwf_noValidJRE, getRuntime().getExecutionEnvironment().getId());
+		String execEnvError = getExecutionEnvironmentError();
+		if( execEnvError != null )
+			return execEnvError;
 		
 		if( !homeDirectoryIsDirectory()) 
 			return Messages.rwf_homeIsNotDirectory;
@@ -346,6 +334,16 @@ public class JBoss7RuntimeWizardFragment extends JBossRuntimeWizardFragment {
 		return null;
 	}
 	
+	@Override
+	protected String getExecutionEnvironmentError() {
+		String sup = super.getExecutionEnvironmentError();
+		if( sup == null ) {
+			if( jreComposite.getValidJREs().size() == 0 ) {
+				return NLS.bind(Messages.rwf_noValidJRE, getRuntime().getExecutionEnvironment().getId());
+			}
+		}
+		return sup;
+	}
 	
 	@Override
 	public String getWarningString() {

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/wizards/JBoss7RuntimeWizardFragment.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/wizards/JBoss7RuntimeWizardFragment.java
@@ -18,7 +18,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.launching.IVMInstall;
-import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
@@ -337,10 +336,8 @@ public class JBoss7RuntimeWizardFragment extends JBossRuntimeWizardFragment {
 	@Override
 	protected String getExecutionEnvironmentError() {
 		String sup = super.getExecutionEnvironmentError();
-		if( sup == null ) {
-			if( jreComposite.getValidJREs().size() == 0 ) {
-				return NLS.bind(Messages.rwf_noValidJRE, getRuntime().getExecutionEnvironment().getId());
-			}
+		if( sup == null && jreComposite.getValidJREs().isEmpty() ) {
+			return NLS.bind(Messages.rwf_noValidJRE, getRuntime().getExecutionEnvironment().getId());
 		}
 		return sup;
 	}

--- a/as/plugins/org.jboss.ide.eclipse.as.ui/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.ui</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss Server Adapter Core Framework
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.wtp.core;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.wtp.core.ASWTPToolsPlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.core.commands;bundle-version="3.6.0",

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.core/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.wtp.core</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss Server Adapter UI Framework
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.wtp.ui;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.ide.eclipse.as.wtp.ui.WTPOveridePlugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.eclipse.core.runtime;bundle-version="3.7.0",

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/pom.xml
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.wtp.ui</artifactId> 

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/src/org/jboss/ide/eclipse/as/wtp/ui/Messages.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/src/org/jboss/ide/eclipse/as/wtp/ui/Messages.java
@@ -57,6 +57,7 @@ public class Messages extends NLS {
 	public static String rwf_jboss7homeNotValid;
 	public static String rwf_homeIncorrectVersionError; 
 	public static String rwf_incompatibleJRE;
+	public static String rwf_incompatibleJREExact;
 	public static String rwf_incompatibleJREMinMax;
 
 	

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/src/org/jboss/ide/eclipse/as/wtp/ui/messages.properties
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/src/org/jboss/ide/eclipse/as/wtp/ui/messages.properties
@@ -38,8 +38,9 @@ rwf_noValidJRE=No valid JREs found for execution environment "{0}"
 rwf_nameTextBlank=The name field must not be blank
 rwf_jboss7homeNotValid=The home directory does not point to a valid server installation.
 rwf_homeIncorrectVersionError=This server type expects a version of {0} but the server directory is of version {1}. This combination may cause critical errors. 
-rwf_incompatibleJRE=This server requires a minimum execution environment of {0}. Caution is advised.
-rwf_incompatibleJREMinMax=This server requires an execution environment between {0} and {1}. Caution is advised.
+rwf_incompatibleJRE=This server requires a minimum execution environment of {0}, but no valid JRE was found. Caution is advised.
+rwf_incompatibleJREExact=This server requires an execution environment of {0}, but no valid JRE was found. Caution is advised.
+rwf_incompatibleJREMinMax=This server requires an execution environment from {0} through {1}, but no valid JRE was found. Caution is advised.
 
 
 

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/src/org/jboss/ide/eclipse/as/wtp/ui/wizard/RuntimeWizardFragment.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/src/org/jboss/ide/eclipse/as/wtp/ui/wizard/RuntimeWizardFragment.java
@@ -242,7 +242,23 @@ public abstract class RuntimeWizardFragment extends WizardFragment {
 		if (getRuntime(name) != null) {
 			return Messages.rwf_NameInUse;
 		}
+			
+		String execEnvError = getExecutionEnvironmentError();
+		if( execEnvError != null )
+			return execEnvError;
 
+		
+		if (name == null || name.equals("")) //$NON-NLS-1$
+			return Messages.rwf_nameTextBlank;
+
+		if( !homeDirComposite.isHomeValid() ) {
+			return Messages.rwf_jboss7homeNotValid;
+		}
+		
+		return null;
+	}
+	
+	protected String getExecutionEnvironmentError() {
 		if( jreComposite != null ) {
 			IExecutionEnvironment selectedEnv = jreComposite.getSelectedExecutionEnvironment();
 			IVMInstall install = jreComposite.getSelectedVM();
@@ -254,15 +270,20 @@ public abstract class RuntimeWizardFragment extends WizardFragment {
 					}
 				}
 			}
+			if( install != null && selectedEnv == null && !jreComposite.getValidJREs().contains(install)) {
+				if( jreComposite.getMaximumExecutionEnvironment() == null ) {
+					return NLS.bind(org.jboss.ide.eclipse.as.wtp.ui.Messages.rwf_incompatibleJRE, 
+							jreComposite.getMinimumExecutionEnvironment().getId());
+				}
+				if( jreComposite.getMinimumExecutionEnvironment().equals(jreComposite.getMaximumExecutionEnvironment() )) {
+					return NLS.bind(org.jboss.ide.eclipse.as.wtp.ui.Messages.rwf_incompatibleJREExact, 
+							jreComposite.getMinimumExecutionEnvironment().getId());
+				}
+				String minSafe = (jreComposite.getMinimumExecutionEnvironment() == null ? "null" : jreComposite.getMinimumExecutionEnvironment().getId());
+				String maxSafe = (jreComposite.getMaximumExecutionEnvironment() == null ? "null" : jreComposite.getMaximumExecutionEnvironment().getId());
+				return NLS.bind(org.jboss.ide.eclipse.as.wtp.ui.Messages.rwf_incompatibleJREMinMax, minSafe, maxSafe);
+			}
 		}
-			
-		if (name == null || name.equals("")) //$NON-NLS-1$
-			return Messages.rwf_nameTextBlank;
-
-		if( !homeDirComposite.isHomeValid() ) {
-			return Messages.rwf_jboss7homeNotValid;
-		}
-		
 		return null;
 	}
 	

--- a/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/src/org/jboss/ide/eclipse/as/wtp/ui/wizard/RuntimeWizardFragment.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.wtp.ui/src/org/jboss/ide/eclipse/as/wtp/ui/wizard/RuntimeWizardFragment.java
@@ -260,27 +260,20 @@ public abstract class RuntimeWizardFragment extends WizardFragment {
 	
 	protected String getExecutionEnvironmentError() {
 		if( jreComposite != null ) {
+			String minSafe = (jreComposite.getMinimumExecutionEnvironment() == null ? "null" : jreComposite.getMinimumExecutionEnvironment().getId());
+			String maxSafe = (jreComposite.getMaximumExecutionEnvironment() == null ? "null" : jreComposite.getMaximumExecutionEnvironment().getId());
 			IExecutionEnvironment selectedEnv = jreComposite.getSelectedExecutionEnvironment();
 			IVMInstall install = jreComposite.getSelectedVM();
-			if( install == null ) {
+			if( install == null && selectedEnv != null && selectedEnv.getCompatibleVMs().length == 0) {
 				// user has selected an exec-env, not a vm
-				if( selectedEnv != null ) {
-					if( selectedEnv.getCompatibleVMs().length == 0 ) {
-						return NLS.bind(Messages.rwf_noValidJRE, selectedEnv.getId());
-					}
-				}
+				return NLS.bind(Messages.rwf_noValidJRE, selectedEnv.getId());
 			}
 			if( install != null && selectedEnv == null && !jreComposite.getValidJREs().contains(install)) {
 				if( jreComposite.getMaximumExecutionEnvironment() == null ) {
-					return NLS.bind(org.jboss.ide.eclipse.as.wtp.ui.Messages.rwf_incompatibleJRE, 
-							jreComposite.getMinimumExecutionEnvironment().getId());
+					return NLS.bind(org.jboss.ide.eclipse.as.wtp.ui.Messages.rwf_incompatibleJRE, minSafe);
+				} else 	if( jreComposite.getMaximumExecutionEnvironment().equals(jreComposite.getMinimumExecutionEnvironment() )) {
+					return NLS.bind(org.jboss.ide.eclipse.as.wtp.ui.Messages.rwf_incompatibleJREExact, minSafe);
 				}
-				if( jreComposite.getMinimumExecutionEnvironment().equals(jreComposite.getMaximumExecutionEnvironment() )) {
-					return NLS.bind(org.jboss.ide.eclipse.as.wtp.ui.Messages.rwf_incompatibleJREExact, 
-							jreComposite.getMinimumExecutionEnvironment().getId());
-				}
-				String minSafe = (jreComposite.getMinimumExecutionEnvironment() == null ? "null" : jreComposite.getMinimumExecutionEnvironment().getId());
-				String maxSafe = (jreComposite.getMaximumExecutionEnvironment() == null ? "null" : jreComposite.getMaximumExecutionEnvironment().getId());
 				return NLS.bind(org.jboss.ide.eclipse.as.wtp.ui.Messages.rwf_incompatibleJREMinMax, minSafe, maxSafe);
 			}
 		}

--- a/as/plugins/org.jboss.tools.as.catalog/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.tools.as.catalog/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.as.catalog;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.tools.as.catalog.ServerCatalogCorePlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.jboss.tools.foundation.core;bundle-version="1.1.0"

--- a/as/plugins/org.jboss.tools.as.catalog/pom.xml
+++ b/as/plugins/org.jboss.tools.as.catalog/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.tools.as.catalog</artifactId> 

--- a/as/plugins/org.jboss.tools.as.runtimes.integration/META-INF/MANIFEST.MF
+++ b/as/plugins/org.jboss.tools.as.runtimes.integration/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-Vendor: %BundleVendor
 Bundle-SymbolicName: org.jboss.tools.as.runtimes.integration;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Activator: org.jboss.tools.as.runtimes.integration.ServerRuntimesIntegrationActivator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources;bundle-version="3.8.100",

--- a/as/plugins/org.jboss.tools.as.runtimes.integration/pom.xml
+++ b/as/plugins/org.jboss.tools.as.runtimes.integration/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.plugins</groupId>
 	<artifactId>org.jboss.tools.as.runtimes.integration</artifactId> 

--- a/as/plugins/pom.xml
+++ b/as/plugins/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>as</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as</groupId>
 	<artifactId>plugins</artifactId>

--- a/as/pom.xml
+++ b/as/pom.xml
@@ -9,7 +9,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>as</artifactId>
 	<name>as.all</name>
-	<version>3.5.2-SNAPSHOT</version>
+	<version>3.5.3-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<modules>
 		<module>plugins</module>

--- a/as/test-framework/org.jboss.ide.eclipse.as.reddeer/META-INF/MANIFEST.MF
+++ b/as/test-framework/org.jboss.ide.eclipse.as.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for AS UI Tests
 Bundle-SymbolicName: org.jboss.ide.eclipse.as.reddeer;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.ui;bundle-version="3.105.0",

--- a/as/test-framework/org.jboss.ide.eclipse.as.reddeer/pom.xml
+++ b/as/test-framework/org.jboss.ide.eclipse.as.reddeer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>test-framework</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.ide.eclipse.as</groupId>
 	<artifactId>org.jboss.ide.eclipse.as.reddeer</artifactId>

--- a/as/test-framework/pom.xml
+++ b/as/test-framework/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>as</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as</groupId>
 	<artifactId>test-framework</artifactId>

--- a/as/tests/org.jboss.tools.as.test.core/META-INF/MANIFEST.MF
+++ b/as/tests/org.jboss.tools.as.test.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-Vendor: %BundleVendor
 Bundle-SymbolicName: org.jboss.tools.as.test.core;singleton:=true
-Bundle-Version: 3.5.2.qualifier
+Bundle-Version: 3.5.3.qualifier
 Bundle-Localization: plugin
 Bundle-Activator: org.jboss.tools.as.test.core.ASMatrixTests
 Require-Bundle: org.eclipse.ui,

--- a/as/tests/org.jboss.tools.as.test.core/pom.xml
+++ b/as/tests/org.jboss.tools.as.test.core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.as</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as.tests</groupId>
 	<artifactId>org.jboss.tools.as.test.core</artifactId> 

--- a/as/tests/pom.xml
+++ b/as/tests/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>as</artifactId>
-		<version>3.5.2-SNAPSHOT</version>
+		<version>3.5.3-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.as</groupId>
 	<artifactId>tests</artifactId>


### PR DESCRIPTION
Signed-off-by: Rob Stryker <rob@oxbeef.net>

There's a bit more to this patch than just what it seems. I also reduced the heirarchy trees of some of these classes because the hierarchies were like 8 deep and most of the time only two or three methods were being overridden. The deep hierarchies were completely unnecessary and often come up as errors or warnings for clean code here in our builds. 