### PR TITLE
JBIDE-26518 Add org.eclipse.equinox.ds in required bundles for server

### DIFF
--- a/as/itests/org.jboss.tools.as.management.itests/META-INF/MANIFEST.MF
+++ b/as/itests/org.jboss.tools.as.management.itests/META-INF/MANIFEST.MF
@@ -19,7 +19,8 @@ Require-Bundle: org.jboss.ide.eclipse.as.core;bundle-version="[3.0.0,4.0.0)",
  org.eclipse.jdt.launching;bundle-version="3.7.0",
  org.eclipse.debug.core;bundle-version="3.9.0",
  org.jboss.ide.eclipse.as.dmr,
- org.jboss.tools.locus.mockito;bundle-version="1.9.5"
+ org.jboss.tools.locus.mockito;bundle-version="1.9.5",
+ org.eclipse.equinox.ds
 Bundle-ClassPath: .,
  wars/
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
management itests

Signed-off-by: Josef Kopriva <jkopriva@redhat.com>