### PR TITLE
JBIDE-26598 - fix JMX navigator local processes with JDK9+ Eclipse

### DIFF
--- a/jmx/plugins/org.jboss.tools.jmx.jvmmonitor.tools/src/org/jboss/tools/jmx/jvmmonitor/internal/tools/JvmAttachHandler.java
+++ b/jmx/plugins/org.jboss.tools.jmx.jvmmonitor.tools/src/org/jboss/tools/jmx/jvmmonitor/internal/tools/JvmAttachHandler.java
@@ -20,6 +20,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChang
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.osgi.util.NLS;
+import org.jboss.tools.common.jdt.debug.JavaUtilities;
 import org.jboss.tools.common.jdt.debug.RemoteDebugActivator;
 import org.jboss.tools.common.jdt.debug.tools.ToolsCore;
 import org.jboss.tools.common.jdt.debug.tools.ToolsCore.AttachedVM;
@@ -233,20 +234,22 @@ public class JvmAttachHandler implements IJvmAttachHandler,
         try {
             virtualMachine = ToolsCore.attach(pid);
 
-            String javaHome = ToolsCore.getSystemProperties(virtualMachine)
-                    .getProperty(IConstants.JAVA_HOME_PROPERTY_KEY);
+            if(!JavaUtilities.isJigsawRunning()) {
+                 String javaHome = ToolsCore.getSystemProperties(virtualMachine)
+            	        .getProperty(IConstants.JAVA_HOME_PROPERTY_KEY);
 
-            File file = new File(javaHome + IConstants.MANAGEMENT_AGENT_JAR);
+                File file = new File(javaHome + IConstants.MANAGEMENT_AGENT_JAR);
 
-            if (!file.exists()) {
-                String message = NLS.bind(Messages.fileNotFoundMsg,
-                        file.getPath());
-                throw new JvmCoreException(IStatus.ERROR, message,
-                        new Exception());
+                if (!file.exists()) {
+                    String message = NLS.bind(Messages.fileNotFoundMsg,
+                            file.getPath());
+                    throw new JvmCoreException(IStatus.ERROR, message,
+                            new Exception());
+                }
+
+                ToolsCore.loadAgent(virtualMachine, file.getAbsolutePath(),
+                        IConstants.JMX_REMOTE_AGENT);
             }
-
-            ToolsCore.loadAgent(virtualMachine, file.getAbsolutePath(),
-                    IConstants.JMX_REMOTE_AGENT);
 
             Properties props = ToolsCore.getAgentProperties(virtualMachine);
             url = (String) props.get(LOCAL_CONNECTOR_ADDRESS);


### PR DESCRIPTION
instance targeting a JDK9+ process

with JDK9+, there is no management-agent.jar put aside in lib folder of
the JDk home. It is available by default.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>