### PR TITLE
Ensuring new add-opens and add-exports are in use

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/EapWildflyJavaVersionFlagUtil.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/EapWildflyJavaVersionFlagUtil.java
@@ -1,0 +1,87 @@
+/******************************************************************************* 
+ * Copyright (c) 2021 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.ide.eclipse.as.core.server.internal.extendedproperties;
+
+import java.util.ArrayList;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.launching.IVMInstall;
+import org.eclipse.wst.server.core.IRuntime;
+import org.jboss.ide.eclipse.as.core.server.IJBossServerRuntime;
+import org.jboss.ide.eclipse.as.core.util.RuntimeUtils;
+import org.jboss.tools.common.jdt.debug.JavaUtilities;
+
+public class EapWildflyJavaVersionFlagUtil {
+	public static boolean isVmJava9(IRuntime rt) {
+		return isVmGTE(rt, 9);
+	}
+
+	public static boolean isVmJava16(IRuntime rt) {
+		return isVmGTE(rt, 16);
+	}
+
+	public static boolean isVmGTE(IRuntime rt, int javaMajor) {
+		try {
+			IJBossServerRuntime jbossRuntime = RuntimeUtils.checkedGetJBossServerRuntime(rt);
+			IVMInstall vmInstall = jbossRuntime.getVM();
+			int[] versionIDs = JavaUtilities.getMajorMinor(JavaUtilities.getJavaVersionVMInstall(vmInstall));
+			if (versionIDs.length > 0 && versionIDs[0] >= javaMajor) {
+				return true;
+			}
+		} catch (CoreException e) {
+			throw new RuntimeException(e);
+		}
+		return false;
+	}
+
+	public static String getJavaVersionVMArgs(IRuntime rt) {
+		
+		if( EapWildflyJavaVersionFlagUtil.isVmJava16(rt)) 
+			return getJava16VMArgsDefault();
+		if( EapWildflyJavaVersionFlagUtil.isVmJava9(rt)) 
+			return getJava9VMArgsDefault();
+		return "";
+	}
+
+	public static String getJava16VMArgsDefault() {
+        final ArrayList<String> modularJavaOpts = new ArrayList<>();
+        // Additions to these should include good explanations why in the relevant JIRA
+        // Keep them alphabetical to avoid the code history getting confused by reordering commits
+        modularJavaOpts.add("--add-exports=java.desktop/sun.awt=ALL-UNNAMED");
+        modularJavaOpts.add("--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED");
+        modularJavaOpts.add("--add-opens=java.base/java.lang=ALL-UNNAMED");
+        modularJavaOpts.add("--add-opens=java.base/java.lang.invoke=ALL-UNNAMED");
+        modularJavaOpts.add("--add-opens=java.base/java.lang.reflect=ALL-UNNAMED");
+        modularJavaOpts.add("--add-opens=java.base/java.io=ALL-UNNAMED");
+        modularJavaOpts.add("--add-opens=java.base/java.security=ALL-UNNAMED");
+        modularJavaOpts.add("--add-opens=java.base/java.util=ALL-UNNAMED");
+        modularJavaOpts.add("--add-opens=java.base/java.util.concurrent=ALL-UNNAMED");
+        modularJavaOpts.add("--add-opens=java.management/javax.management=ALL-UNNAMED");
+        modularJavaOpts.add("--add-opens=java.naming/javax.naming=ALL-UNNAMED");
+        modularJavaOpts.add("--add-exports=java.base/sun.nio.ch=ALL-UNNAMED");
+        modularJavaOpts.add("--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED");
+        modularJavaOpts.add("--add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED");
+        modularJavaOpts.add("--add-modules=java.se");
+		return " " + String.join(" ", modularJavaOpts);
+	}
+	
+	public static String getJava9VMArgsDefault() {
+        final ArrayList<String> modularJavaOpts = new ArrayList<>();
+        // Additions to these should include good explanations why in the relevant JIRA
+        // Keep them alphabetical to avoid the code history getting confused by reordering commits
+        modularJavaOpts.add("--add-exports=java.base/sun.nio.ch=ALL-UNNAMED");
+        modularJavaOpts.add("--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED");
+        modularJavaOpts.add("--add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED");
+        modularJavaOpts.add("--add-modules=java.se");
+		return " " + String.join(" ", modularJavaOpts);
+	}
+	
+}

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossEAP72DefaultLaunchArguments.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossEAP72DefaultLaunchArguments.java
@@ -10,13 +10,8 @@
  ******************************************************************************/
 package org.jboss.ide.eclipse.as.core.server.internal.extendedproperties;
 
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.wst.server.core.IRuntime;
 import org.eclipse.wst.server.core.IServer;
-import org.jboss.ide.eclipse.as.core.server.IJBossServerRuntime;
-import org.jboss.ide.eclipse.as.core.util.RuntimeUtils;
-import org.jboss.tools.common.jdt.debug.JavaUtilities;
 
 public class JBossEAP72DefaultLaunchArguments extends
 JBossEAP70DefaultLaunchArguments {
@@ -27,35 +22,12 @@ JBossEAP70DefaultLaunchArguments {
 		super(rt);
 	}
 	
-	public static String getJava9VMArgsConditional(IRuntime rt) {
-		if( isVmJava9(rt)) 
-			return getJava9VMArgsDefault();
-		return "";
-	}
-	public static boolean isVmJava9(IRuntime rt) {
-		try {
-			IJBossServerRuntime jbossRuntime = RuntimeUtils.checkedGetJBossServerRuntime(rt);
-			IVMInstall vmInstall = jbossRuntime.getVM();
-			int[] versionIDs = JavaUtilities.getMajorMinor(JavaUtilities.getJavaVersionVMInstall(vmInstall));
-			if (versionIDs.length > 0 && versionIDs[0] >= 9) {
-				return true;
-			}
-		} catch (CoreException e) {
-			throw new RuntimeException(e);
-		}
-		return false;
-	}
-	
-	public static String getJava9VMArgsDefault() {
-		return " --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED --add-modules=java.se";
-	}
-	
-	protected String getJava9VMArgs() {
-		return getJava9VMArgsConditional(getRuntime());
+	protected String getJavaVersionVMArgs() {
+		return EapWildflyJavaVersionFlagUtil.getJavaVersionVMArgs(getRuntime());
 	}
 	
 	@Override
 	public String getStartDefaultVMArgs() {
-		return super.getStartDefaultVMArgs() + getJava9VMArgs();
+		return super.getStartDefaultVMArgs() + getJavaVersionVMArgs();
 	}
 }

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossEAP73DefaultLaunchArguments.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/JBossEAP73DefaultLaunchArguments.java
@@ -23,12 +23,8 @@ public class JBossEAP73DefaultLaunchArguments extends JBossEAP70DefaultLaunchArg
 		super(rt);
 	}
 	
-	protected String getJava9VMArgs() {
-		return JBossEAP72DefaultLaunchArguments.getJava9VMArgsConditional(getRuntime());
-	}
-	
 	@Override
 	public String getStartDefaultVMArgs() {
-		return super.getStartDefaultVMArgs() + getJava9VMArgs();
+		return super.getStartDefaultVMArgs() + EapWildflyJavaVersionFlagUtil.getJavaVersionVMArgs(getRuntime());
 	}
 }

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/Wildfly150DefaultLaunchArguments.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/extendedproperties/Wildfly150DefaultLaunchArguments.java
@@ -21,13 +21,9 @@ public class Wildfly150DefaultLaunchArguments extends
 	public Wildfly150DefaultLaunchArguments(IRuntime rt) {
 		super(rt);
 	}
-
-	protected String getJava9VMArgs() {
-		return JBossEAP72DefaultLaunchArguments.getJava9VMArgsConditional(getRuntime());
-	}
 	
 	@Override
 	public String getStartDefaultVMArgs() {
-		return super.getStartDefaultVMArgs() + getJava9VMArgs();
+		return super.getStartDefaultVMArgs() + EapWildflyJavaVersionFlagUtil.getJavaVersionVMArgs(getRuntime());
 	}
 }

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/launch/configuration/JBossLaunchConfigProperties.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/launch/configuration/JBossLaunchConfigProperties.java
@@ -25,6 +25,7 @@ import org.eclipse.wst.server.core.IServer;
 import org.eclipse.wst.server.core.ServerCore;
 import org.jboss.ide.eclipse.as.core.server.IJBossServerRuntime;
 import org.jboss.ide.eclipse.as.core.server.bean.ServerBeanLoader;
+import org.jboss.ide.eclipse.as.core.server.internal.extendedproperties.EapWildflyJavaVersionFlagUtil;
 import org.jboss.ide.eclipse.as.core.server.internal.extendedproperties.JBossEAP72DefaultLaunchArguments;
 import org.jboss.ide.eclipse.as.core.util.ArgsUtil;
 import org.jboss.ide.eclipse.as.core.util.IJBossRuntimeConstants;
@@ -172,18 +173,23 @@ public class JBossLaunchConfigProperties {
 	}
 
 	
-	public void setOrClearJava9Flags(IJBossServerRuntime runtime,
+	public void setOrClearJavaVersionFlags(IJBossServerRuntime runtime,
 			ILaunchConfigurationWorkingCopy launchConfig) throws CoreException {
 		String args = getVMArguments(launchConfig);
-		String j9DefaultArgs = JBossEAP72DefaultLaunchArguments.getJava9VMArgsDefault().trim();
-		boolean isVmJ9 = JBossEAP72DefaultLaunchArguments.isVmJava9(runtime.getRuntime());
-		String newArgs = "";
-		if( isVmJ9 && !args.contains(j9DefaultArgs)) {
-			newArgs = args + IJBossRuntimeConstants.SPACE + j9DefaultArgs;
-		} else if( !isVmJ9 && args.contains(j9DefaultArgs)) {
-			newArgs = args.replace(j9DefaultArgs, "");
+		boolean is16 = EapWildflyJavaVersionFlagUtil.isVmJava16(runtime.getRuntime()); 
+		boolean is9 = EapWildflyJavaVersionFlagUtil.isVmJava9(runtime.getRuntime());
+		if( !is16) {
+			args = args.replace(EapWildflyJavaVersionFlagUtil.getJava16VMArgsDefault(), "");
 		}
-		setVmArguments(newArgs, launchConfig);
+		if( !is9) {
+			args = args.replace(EapWildflyJavaVersionFlagUtil.getJava9VMArgsDefault(), "");
+		}
+		
+		String versionArgs = EapWildflyJavaVersionFlagUtil.getJavaVersionVMArgs(runtime.getRuntime());
+		if( !args.contains(versionArgs)) {
+			args = args + IJBossRuntimeConstants.SPACE + versionArgs;
+		}
+		setVmArguments(args, launchConfig);
 	}
 
 	/**

--- a/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/v7/LocalJBoss7StartConfigurator.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.core/jbosscore/org/jboss/ide/eclipse/as/core/server/internal/v7/LocalJBoss7StartConfigurator.java
@@ -60,7 +60,7 @@ public class LocalJBoss7StartConfigurator extends AbstractStartLaunchConfigurato
 		getProperties().setHost(getHost(jbossServer, jbossRuntime), launchConfig);
 		getProperties().setServerHome(getServerHome(jbossRuntime), jbossRuntime, launchConfig);
 		getProperties().setServerFlag(getSupportsServerFlag(jbossRuntime), jbossRuntime, launchConfig);
-		getProperties().setOrClearJava9Flags(jbossRuntime, launchConfig);
+		getProperties().setOrClearJavaVersionFlags(jbossRuntime, launchConfig);
 		getProperties().setJreContainer(getJreContainerPath(jbossRuntime), launchConfig);
 		getProperties().setEndorsedDir(getEndorsedDir(jbossRuntime), launchConfig);
 		getProperties().setJavaLibPath(getJavaLibraryPath(jbossRuntime), launchConfig);


### PR DESCRIPTION
Signed-off-by: Rob Stryker <rob@oxbeef.net>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
