### PR TITLE
JBIDE-28000: allow non-https redirects on MacOS

### DIFF
--- a/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/launch/JBTWebLaunchableClient.java
+++ b/as/plugins/org.jboss.ide.eclipse.as.ui/jbossui/org/jboss/ide/eclipse/as/ui/launch/JBTWebLaunchableClient.java
@@ -34,6 +34,7 @@ import org.jboss.ide.eclipse.as.core.server.IServerModuleStateVerifier;
 import org.jboss.ide.eclipse.as.core.server.internal.JBossLaunchAdapter.JBTCustomHttpLaunchable;
 import org.jboss.ide.eclipse.as.core.server.internal.extendedproperties.ServerExtendedProperties;
 import org.jboss.ide.eclipse.as.ui.JBossServerUIPlugin;
+import org.jboss.tools.foundation.ui.util.BrowserUtility;
 
 public class JBTWebLaunchableClient extends ClientDelegate {
 
@@ -129,6 +130,7 @@ public class JBTWebLaunchableClient extends ClientDelegate {
 	private static final String BROWSER_COULD_NOT_OPEN_BROWSER = "Unable to open web browser"; //$NON-NLS-1$
 	public static void checkedCreateInternalBrowser(String url, String browserId, String pluginId, ILog log) {
 		try {
+			BrowserUtility.allowNonHttpsRedirects();
 			openUrl(url, PlatformUI.getWorkbench().getBrowserSupport().createBrowser(IWorkbenchBrowserSupport.LOCATION_BAR | IWorkbenchBrowserSupport.NAVIGATION_BAR, browserId, null, null), pluginId, log);
 		} catch (PartInitException e) {
 			IStatus errorStatus = createErrorStatus(pluginId, BROWSER_COULD_NOT_OPEN_BROWSER, e, url);


### PR DESCRIPTION
depends on https://github.com/jbosstools/jbosstools-base/pull/710
fixes https://issues.redhat.com/browse/JBIDE-28000

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
