### PR TITLE
Fix jmx ITests paths

### DIFF
--- a/as/itests/org.jboss.tools.as.jmx.ui.bot.itests/pom.xml
+++ b/as/itests/org.jboss.tools.as.jmx.ui.bot.itests/pom.xml
@@ -16,15 +16,15 @@
 		<maven.test.failure.ignore>true</maven.test.failure.ignore>
 		<rd.config>${project.build.directory}/classes/requirements.json</rd.config>
 		<skipPrivateRequirements>false</skipPrivateRequirements>
-		<systemProperties>-Drd.config=${rd.config} -Dusage_reporting_enabled=false -Djbosstools.test.wildfly.21.home=${jbosstools.test.wildfly.21.home} -Djbosstools.test.wildfly.22.home=${jbosstools.test.wildfly.22.home} -Djbosstools.test.eap.7.3.home=${jbosstools.test.eap.7.3.home} -Dusername=${username} -Dpassword=${password} -Dremote.system.type=${remote.system.type}</systemProperties>
+		<systemProperties>-Drd.config=${rd.config} -Dusage_reporting_enabled=false -Djbosstools.test.wildfly.23.home=${jbosstools.test.wildfly.23.home} -Djbosstools.test.wildfly.24.home=${jbosstools.test.wildfly.24.home} -Djbosstools.test.eap.7.4.home=${jbosstools.test.eap.7.4.home} -Dusername=${username} -Dpassword=${password} -Dremote.system.type=${remote.system.type}</systemProperties>
 		<surefire.timeout>14400</surefire.timeout>
 		<username></username>
 		<password></password>
 		<server.host></server.host>
 		<remote.system.type></remote.system.type>
-		<jbosstools.test.wildfly.21.home>${jbosstools.test.jboss.home.21.0}</jbosstools.test.wildfly.21.home>
-		<jbosstools.test.wildfly.22.home>${jbosstools.test.jboss.home.22.0}</jbosstools.test.wildfly.22.home>
-		<jbosstools.test.eap.7.3.home>${jbosstools.test.jboss.home.eap.7.3}</jbosstools.test.eap.7.3.home>
+		<jbosstools.test.wildfly.23.home>${jbosstools.test.jboss.home.23.0}</jbosstools.test.wildfly.23.home>
+		<jbosstools.test.wildfly.24.home>${jbosstools.test.jboss.home.24.0}</jbosstools.test.wildfly.24.home>
+		<jbosstools.test.eap.7.4.home>${jbosstools.test.jboss.home.eap.7.4}</jbosstools.test.eap.7.4.home>
 		<suiteClass>org.jboss.tools.as.jmx.ui.bot.itests.JMXAllTests</suiteClass>
 	</properties>
 


### PR DESCRIPTION
Signed-off-by: Josef Kopriva <jkopriva@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
