### PR TITLE
Use internal browser requirement added to SingleServerRuntimeTest

### DIFF
--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/server/SingleServerRuntimeTest.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/server/SingleServerRuntimeTest.java
@@ -20,6 +20,7 @@ import org.eclipse.reddeer.direct.preferences.Preferences;
 import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.Server;
 import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.ServersView2;
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
+import org.eclipse.reddeer.requirements.browser.InternalBrowserRequirement.UseInternalBrowser;
 import org.eclipse.ui.PlatformUI;
 import org.jboss.ide.eclipse.as.reddeer.server.view.JBossServer;
 import org.jboss.tools.as.ui.bot.itests.Activator;
@@ -48,6 +49,7 @@ import org.junit.runners.MethodSorters;
 @RunWith(RedDeerSuite.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING) // first acquireAndDetect, then detect, then operate
 @DisableSecureStorage
+@UseInternalBrowser
 public class SingleServerRuntimeTest {
 
 	private String location;


### PR DESCRIPTION
Signed-off-by: Ondrej Dockal <odockal@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
