### PR TITLE
server-itests fixed/reworked due to migrate from CRS to Eclipse + JBT

### DIFF
--- a/archives/tests/org.jboss.ide.eclipse.archives.ui.test/src/org/jboss/ide/eclipse/archives/ui/test/bot/ArchivesTestBase.java
+++ b/archives/tests/org.jboss.ide.eclipse.archives.ui.test/src/org/jboss/ide/eclipse/archives/ui/test/bot/ArchivesTestBase.java
@@ -19,6 +19,7 @@ import org.eclipse.reddeer.common.logging.Logger;
 import org.eclipse.reddeer.common.wait.TimePeriod;
 import org.eclipse.reddeer.common.wait.WaitUntil;
 import org.eclipse.reddeer.common.wait.WaitWhile;
+import org.eclipse.reddeer.direct.preferences.Preferences;
 import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
 import org.eclipse.reddeer.eclipse.condition.ProjectExists;
 import org.eclipse.reddeer.eclipse.jdt.ui.wizards.JavaProjectWizard;
@@ -50,6 +51,7 @@ public class ArchivesTestBase{
 	
 	@BeforeClass
 	public static void maximizeWorkbench(){
+		Preferences.set("org.eclipse.debug.ui", "Console.limitConsoleOutput", "false");
 		new WorkbenchShell().maximize();
 	}
 	

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/AllTestsSuite.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/AllTestsSuite.java
@@ -24,7 +24,7 @@ import org.junit.runners.Suite;
 
 @RunWith(RedDeerSuite.class)
 @Suite.SuiteClasses({ 
-	InvalidCredentialProductDownloadTest.class, 
+	InvalidCredentialProductDownloadTest.class,
 	ServerRuntimesTest.class,
 	VariousProjectsArchiving.class,
 	DeployingArchiveTest.class,

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/archives/DeployingArchiveTest.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/archives/DeployingArchiveTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.util.List;
 
+import org.eclipse.reddeer.direct.preferences.Preferences;
 import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.Server;
 import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.ServersView2;
 import org.eclipse.reddeer.eclipse.wst.server.ui.wizard.ModifyModulesDialog;
@@ -54,6 +55,7 @@ public class DeployingArchiveTest extends ArchivesTestBase {
 	
 	@BeforeClass
 	public static void setup() {
+		Preferences.set("org.eclipse.debug.ui", "Console.limitConsoleOutput", "false");
 		deleteRuntimes();
 		createJavaProject(projectName);
 		addArchivesSupport(projectName);

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/archives/VariousProjectsArchiving.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/archives/VariousProjectsArchiving.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 
 import org.jboss.ide.eclipse.archives.ui.test.bot.ArchivesTestBase;
-import org.eclipse.reddeer.direct.preferences.Preferences;
 import org.eclipse.reddeer.eclipse.jst.ejb.ui.project.facet.EjbProjectFirstPage;
 import org.eclipse.reddeer.eclipse.jst.ejb.ui.project.facet.EjbProjectWizard;
 import org.eclipse.reddeer.eclipse.jst.servlet.ui.project.facet.WebProjectFirstPage;
@@ -48,7 +47,6 @@ public class VariousProjectsArchiving extends ArchivesTestBase {
 	
 	@BeforeClass
 	public static void setup() {
-		Preferences.set("org.eclipse.debug.ui", "Console.limitConsoleOutput", "false");
 		AbstractTest.deleteRuntimes();
 		File f = Activator.getDownloadFolder(SMOKETEST_TYPE);
 		if( !f.exists() || f.list() == null || f.list().length == 0 ) {

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/archives/VariousProjectsArchiving.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/archives/VariousProjectsArchiving.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 
 import org.jboss.ide.eclipse.archives.ui.test.bot.ArchivesTestBase;
+import org.eclipse.reddeer.direct.preferences.Preferences;
 import org.eclipse.reddeer.eclipse.jst.ejb.ui.project.facet.EjbProjectFirstPage;
 import org.eclipse.reddeer.eclipse.jst.ejb.ui.project.facet.EjbProjectWizard;
 import org.eclipse.reddeer.eclipse.jst.servlet.ui.project.facet.WebProjectFirstPage;
@@ -47,6 +48,7 @@ public class VariousProjectsArchiving extends ArchivesTestBase {
 	
 	@BeforeClass
 	public static void setup() {
+		Preferences.set("org.eclipse.debug.ui", "Console.limitConsoleOutput", "false");
 		AbstractTest.deleteRuntimes();
 		File f = Activator.getDownloadFolder(SMOKETEST_TYPE);
 		if( !f.exists() || f.list() == null || f.list().length == 0 ) {

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/RuntimeDetectionDuplicatesTest.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/RuntimeDetectionDuplicatesTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.eclipse.core.runtime.Path;
 import org.eclipse.reddeer.common.wait.WaitWhile;
+import org.eclipse.reddeer.direct.preferences.Preferences;
 import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
 import org.eclipse.reddeer.junit.internal.runner.ParameterizedRequirementsRunnerFactory;
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
@@ -58,6 +59,7 @@ public class RuntimeDetectionDuplicatesTest extends TestCase {
     
     @BeforeClass
     public static void prepare() {
+    	Preferences.set("org.eclipse.debug.ui", "Console.limitConsoleOutput", "false");
     	AbstractTest.deleteRuntimes();
     }
     

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/ServerActualJavaTest.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/ServerActualJavaTest.java
@@ -19,6 +19,7 @@ import org.eclipse.reddeer.common.logging.Logger;
 import org.eclipse.reddeer.common.matcher.VersionMatcher;
 import org.eclipse.reddeer.common.wait.AbstractWait;
 import org.eclipse.reddeer.common.wait.TimePeriod;
+import org.eclipse.reddeer.direct.preferences.Preferences;
 import org.eclipse.reddeer.eclipse.wst.server.ui.wizard.NewServerWizard;
 import org.eclipse.reddeer.eclipse.wst.server.ui.wizard.NewServerWizardPage;
 import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
@@ -76,6 +77,7 @@ private final Logger LOGGER = Logger.getLogger(this.getClass());
 
 	@BeforeClass
 	public static void prepareWorkspace() {
+		Preferences.set("org.eclipse.debug.ui", "Console.limitConsoleOutput", "false");
 		deleteRuntimes();
 	}
 

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/ServerAdaptersTest.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/ServerAdaptersTest.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import org.eclipse.reddeer.common.exception.RedDeerException;
 import org.eclipse.reddeer.common.logging.Logger;
 import org.eclipse.reddeer.common.matcher.VersionMatcher;
+import org.eclipse.reddeer.direct.preferences.Preferences;
 import org.eclipse.reddeer.eclipse.wst.server.ui.wizard.NewServerWizard;
 import org.eclipse.reddeer.eclipse.wst.server.ui.wizard.NewServerWizardPage;
 import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
@@ -80,6 +81,7 @@ public class ServerAdaptersTest extends AbstractTest {
 
 	@BeforeClass
 	public static void prepareWorkspace() {
+		Preferences.set("org.eclipse.debug.ui", "Console.limitConsoleOutput", "false");
 		deleteRuntimes();
 	}
 

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/ServerRuntimesTest.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/ServerRuntimesTest.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 
 import org.eclipse.reddeer.common.matcher.VersionMatcher;
 import org.eclipse.reddeer.common.util.Display;
+import org.eclipse.reddeer.direct.preferences.Preferences;
 import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.ServersView2;
 import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
 import org.eclipse.reddeer.junit.internal.runner.ParameterizedRequirementsRunnerFactory;
@@ -117,6 +118,7 @@ public class ServerRuntimesTest extends AbstractTest {
 
     @BeforeClass
     public static void deleteRuntimesAddedByRuntimeDetection() {
+    	Preferences.set("org.eclipse.debug.ui", "Console.limitConsoleOutput", "false");
     	deleteRuntimes();
     }
     

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/ShowInContextMenuTest.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/ShowInContextMenuTest.java
@@ -15,8 +15,12 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import org.eclipse.reddeer.common.exception.WaitTimeoutExpiredException;
+import org.eclipse.reddeer.common.matcher.RegexMatcher;
 import org.eclipse.reddeer.common.wait.TimePeriod;
 import org.eclipse.reddeer.common.wait.WaitUntil;
+import org.eclipse.reddeer.common.wait.WaitWhile;
+import org.eclipse.reddeer.direct.preferences.Preferences;
 import org.eclipse.reddeer.eclipse.condition.BrowserContainsText;
 import org.eclipse.reddeer.eclipse.debug.ui.views.launch.LaunchView;
 import org.eclipse.reddeer.eclipse.ui.console.ConsoleView;
@@ -30,9 +34,15 @@ import org.eclipse.reddeer.swt.api.MenuItem;
 import org.eclipse.reddeer.swt.api.TreeItem;
 import org.eclipse.reddeer.swt.condition.PageIsLoaded;
 import org.eclipse.reddeer.swt.impl.browser.InternalBrowser;
+import org.eclipse.reddeer.swt.impl.ctab.DefaultCTabFolder;
 import org.eclipse.reddeer.swt.impl.menu.ContextMenu;
+import org.eclipse.reddeer.swt.impl.menu.ContextMenuItem;
+import org.eclipse.reddeer.swt.impl.toolbar.DefaultToolBar;
+import org.eclipse.reddeer.swt.impl.toolbar.DefaultToolItem;
+import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
 import org.eclipse.reddeer.workbench.core.exception.WorkbenchCoreLayerException;
 import org.eclipse.reddeer.workbench.impl.editor.DefaultEditor;
+import org.eclipse.wst.server.ui.internal.view.servers.ServersView;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.InternalBrowserRequirement.UseInternalBrowser;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.jmx.reddeer.core.JMXConnection;
@@ -61,6 +71,7 @@ public class ShowInContextMenuTest {
 	
 	@Before
 	public void selectServer() {
+		Preferences.set("org.eclipse.debug.ui", "Console.limitConsoleOutput", "false");
 		sv = new ServersView2();
 		sv.open();
 		server = sv.getServer("WildFly 24+ Server");
@@ -69,9 +80,19 @@ public class ShowInContextMenuTest {
 	
 	@After
 	public void cleanUp() {
+		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
 		if(server.getLabel().getState().isRunningState()) {
-			server.stop();
+			new ConsoleView().activate();
+			new ConsoleView().terminateConsole();
+			new ServersView2().activate();
 		}
+		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
+		if(server.getLabel().getState().isRunningState()) {
+			new ConsoleView().activate();
+			new ConsoleView().terminateConsole();
+			new ServersView2().activate();
+		}
+		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
 		sv.close();
 		try {
 			new DefaultEditor().close();

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/ShowInContextMenuTest.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/ShowInContextMenuTest.java
@@ -15,8 +15,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import org.eclipse.reddeer.common.exception.WaitTimeoutExpiredException;
-import org.eclipse.reddeer.common.matcher.RegexMatcher;
 import org.eclipse.reddeer.common.wait.TimePeriod;
 import org.eclipse.reddeer.common.wait.WaitUntil;
 import org.eclipse.reddeer.common.wait.WaitWhile;
@@ -27,29 +25,24 @@ import org.eclipse.reddeer.eclipse.ui.console.ConsoleView;
 import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.Server;
 import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.ServersView2;
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
+import org.eclipse.reddeer.requirements.browser.InternalBrowserRequirement.UseInternalBrowser;
 import org.eclipse.reddeer.requirements.closeeditors.CloseAllEditorsRequirement.CloseAllEditors;
 import org.eclipse.reddeer.requirements.server.ServerRequirementState;
 import org.eclipse.reddeer.swt.api.Browser;
 import org.eclipse.reddeer.swt.api.MenuItem;
 import org.eclipse.reddeer.swt.api.TreeItem;
-import org.eclipse.reddeer.swt.condition.PageIsLoaded;
 import org.eclipse.reddeer.swt.impl.browser.InternalBrowser;
-import org.eclipse.reddeer.swt.impl.ctab.DefaultCTabFolder;
 import org.eclipse.reddeer.swt.impl.menu.ContextMenu;
-import org.eclipse.reddeer.swt.impl.menu.ContextMenuItem;
-import org.eclipse.reddeer.swt.impl.toolbar.DefaultToolBar;
-import org.eclipse.reddeer.swt.impl.toolbar.DefaultToolItem;
 import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
 import org.eclipse.reddeer.workbench.core.exception.WorkbenchCoreLayerException;
 import org.eclipse.reddeer.workbench.impl.editor.DefaultEditor;
-import org.eclipse.wst.server.ui.internal.view.servers.ServersView;
-import org.jboss.ide.eclipse.as.reddeer.server.requirement.InternalBrowserRequirement.UseInternalBrowser;
 import org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer;
 import org.jboss.tools.jmx.reddeer.core.JMXConnection;
 import org.jboss.tools.jmx.reddeer.core.JMXConnectionItem;
 import org.jboss.tools.jmx.reddeer.ui.view.JMXNavigatorView;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -69,9 +62,13 @@ public class ShowInContextMenuTest {
 	private ServersView2 sv;
 	private Server server;
 	
+	@BeforeClass
+	public static void setup() {
+		Preferences.set("org.eclipse.debug.ui", "Console.limitConsoleOutput", "false");
+	}
+	
 	@Before
 	public void selectServer() {
-		Preferences.set("org.eclipse.debug.ui", "Console.limitConsoleOutput", "false");
 		sv = new ServersView2();
 		sv.open();
 		server = sv.getServer("WildFly 24+ Server");

--- a/as/itests/pom.xml
+++ b/as/itests/pom.xml
@@ -19,6 +19,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
 	<properties>
 		<enforceFailOnUIDependencyInCore>false</enforceFailOnUIDependencyInCore>
+		<jbosstools.test.jboss.home.24.0>${requirementsDirectory}/wildfly-24.0.0.Final</jbosstools.test.jboss.home.24.0>
 		<jbosstools.test.jboss.home.25.0>${requirementsDirectory}/wildfly-25.0.1.Final</jbosstools.test.jboss.home.25.0>
 		<jbosstools.test.jboss.home.26.0>${requirementsDirectory}/wildfly-26.0.0.Final</jbosstools.test.jboss.home.26.0>
 		<jbosstools.test.jboss.home.eap.7.0>${requirementsDirectory}/jboss-eap-7.0</jbosstools.test.jboss.home.eap.7.0>
@@ -29,7 +30,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		<additionalProperties></additionalProperties>
 		<!-- skipPrivateRequirements and skipTestsWithPrivateRequirements are inherited from parent pom -->
 		<runtimes.suite.scope>smoke</runtimes.suite.scope>
-		<systemProperties>-Djbosstools.test.jre.8=${jbosstools.test.jre.8} -Djbosstools.test.jre.11=${jbosstools.test.jre.11} -Djbosstools.test.jre.17=${jbosstools.test.jre.17} -Djbosstools.test.jboss.home.25.0=${jbosstools.test.jboss.home.25.0} -Djbosstools.test.jboss.home.26.0=${jbosstools.test.jboss.home.26.0}  -Djbosstools.test.jboss.home.eap.7.0=${jbosstools.test.jboss.home.eap.7.0} -Djbosstools.test.jboss.home.eap.7.1=${jbosstools.test.jboss.home.eap.7.1} -Djbosstools.test.jboss.home.eap.7.2=${jbosstools.test.jboss.home.eap.7.2} -Djbosstools.test.jboss.home.eap.7.3=${jbosstools.test.jboss.home.eap.7.3} -Djbosstools.test.jboss.home.eap.7.4=${jbosstools.test.jboss.home.eap.7.4} -Dorg.jboss.tools.tests.skipPrivateRequirements=${skipPrivateRequirements} -Dorg.jboss.tools.tests.skipTestsWithPrivateRequirements=${skipTestsWithPrivateRequirements} -Djboss.org.username=${jboss.org.username} -Djboss.org.password=${jboss.org.password} -Djbosstools.test.singleruntime.location=${jbosstools.test.singleruntime.location} -Druntimes.suite.scope=${runtimes.suite.scope} ${additionalProperties}</systemProperties>
+		<systemProperties>-Djbosstools.test.jre.8=${jbosstools.test.jre.8} -Djbosstools.test.jre.11=${jbosstools.test.jre.11} -Djbosstools.test.jre.17=${jbosstools.test.jre.17} -Djbosstools.test.jboss.home.24.0=${jbosstools.test.jboss.home.24.0} -Djbosstools.test.jboss.home.25.0=${jbosstools.test.jboss.home.25.0} -Djbosstools.test.jboss.home.26.0=${jbosstools.test.jboss.home.26.0}  -Djbosstools.test.jboss.home.eap.7.0=${jbosstools.test.jboss.home.eap.7.0} -Djbosstools.test.jboss.home.eap.7.1=${jbosstools.test.jboss.home.eap.7.1} -Djbosstools.test.jboss.home.eap.7.2=${jbosstools.test.jboss.home.eap.7.2} -Djbosstools.test.jboss.home.eap.7.3=${jbosstools.test.jboss.home.eap.7.3} -Djbosstools.test.jboss.home.eap.7.4=${jbosstools.test.jboss.home.eap.7.4} -Dorg.jboss.tools.tests.skipPrivateRequirements=${skipPrivateRequirements} -Dorg.jboss.tools.tests.skipTestsWithPrivateRequirements=${skipTestsWithPrivateRequirements} -Djboss.org.username=${jboss.org.username} -Djboss.org.password=${jboss.org.password} -Djbosstools.test.singleruntime.location=${jbosstools.test.singleruntime.location} -Druntimes.suite.scope=${runtimes.suite.scope} ${additionalProperties}</systemProperties>
 	</properties>
 
 	<build>
@@ -184,6 +185,19 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 									<md5>feddc39d58a29b1ed9791121a77e8b49</md5>
 									<unpack>true</unpack>
 									<skip>${skipTestsWithPrivateRequirements}</skip>
+								</configuration>
+							</execution>
+							<execution>
+								<id>install-wildfly-24.0.0.Final</id>
+								<phase>pre-integration-test</phase>
+								<goals>
+									<goal>wget</goal>
+								</goals>
+								<configuration>
+									<url>https://download.jboss.org/wildfly/24.0.0.Final/wildfly-24.0.0.Final.zip</url>
+									<sha1>708451bb57d679f64a84010af9cbb5d19cf89c8a</sha1>
+									<unpack>true</unpack>
+									<skip>${skipTestsOrITests}</skip>
 								</configuration>
 							</execution>
 							<execution>

--- a/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/internal/utils/ServerParameterUtils.java
+++ b/as/tests/org.jboss.tools.as.test.core/src/org/jboss/tools/as/test/core/internal/utils/ServerParameterUtils.java
@@ -35,7 +35,6 @@ public class ServerParameterUtils {
 	
 	static {
 		// AUTOGEN_SERVER_ADAPTER_CHUNK
-		TESTED_SERVERS.add(IJBossToolingConstants.SERVER_WILDFLY_230);
 		TESTED_SERVERS.add(IJBossToolingConstants.SERVER_WILDFLY_240);
 		// AUTOGEN_SERVER_ADAPTER_CHUNK
 		TESTED_SERVERS.add(IJBossToolingConstants.SERVER_EAP_72); 


### PR DESCRIPTION
Signed-off-by: Oleksii Korniienko <olkornii@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work? https://studio-jenkins-csb-codeready.apps.ocp-c1.prod.psi.redhat.com/job/Studio/job/Quality/job/Integration-tests/job/server-itests/jdk=openjdk-17,label=ubuntu2004/355/
