### PR TITLE
Update wf/eap version

### DIFF
--- a/as/itests/org.jboss.tools.as.jmx.ui.bot.itests/pom.xml
+++ b/as/itests/org.jboss.tools.as.jmx.ui.bot.itests/pom.xml
@@ -23,7 +23,7 @@
 		<server.host></server.host>
 		<remote.system.type></remote.system.type>
 		<jbosstools.test.wildfly.25.home>${jbosstools.test.jboss.home.25.0}</jbosstools.test.wildfly.25.home>
-		<jbosstools.test.wildfly.26.home>${jbosstools.test.jboss.home.26.0}</jbosstools.test.wildfly.26.home>
+		<jbosstools.test.wildfly.26.home>${jbosstools.test.jboss.home.26.1}</jbosstools.test.wildfly.26.home>
 		<jbosstools.test.eap.7.4.home>${jbosstools.test.jboss.home.eap.7.4}</jbosstools.test.eap.7.4.home>
 		<suiteClass>org.jboss.tools.as.jmx.ui.bot.itests.JMXAllTests</suiteClass>
 	</properties>

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/pom.xml
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/pom.xml
@@ -59,7 +59,7 @@
 			<properties>
 				<test.class>org.jboss.tools.as.ui.bot.itests.EAPTestsSuite</test.class>
 				<jbosstools.test.jboss-server.home>jboss-eap-7.4</jbosstools.test.jboss-server.home>
-				<jbosstools.test.single.runtime.server.identification>Red Hat JBoss EAP 7.4.0</jbosstools.test.single.runtime.server.identification>
+				<jbosstools.test.single.runtime.server.identification>Red Hat JBoss EAP 7.4.6</jbosstools.test.single.runtime.server.identification>
 				<jbosstools.test.single.runtime.product.slot>eap</jbosstools.test.single.runtime.product.slot>
 				<jbosstools.test.single.runtime.product.release.name>JBoss EAP</jbosstools.test.single.runtime.product.release.name>
 				<jbosstools.test.single.runtime.server.adapter.label>Red Hat JBoss Enterprise Application Platform 7.4</jbosstools.test.single.runtime.server.adapter.label>

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/requirements/jre.json
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/requirements/jre.json
@@ -18,7 +18,7 @@
 	],
 	"org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer": [
 		{
-			"runtime": "${jbosstools.test.jboss.home.26.0}",
+			"runtime": "${jbosstools.test.jboss.home.26.1}",
 			"version": "24+",
 			"family": "WILDFLY"
 		}

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/requirements/wildfly-requirement.json
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/requirements/wildfly-requirement.json
@@ -1,7 +1,14 @@
 {
+	"org.eclipse.reddeer.requirements.jre.JRERequirement.JRE": [
+		{
+			"name": "openjdk-1.8",
+			"version": "1.8",
+			"path": "${jbosstools.test.jre.8}"
+		}
+	],
 	"org.jboss.ide.eclipse.as.reddeer.server.requirement.ServerRequirement.JBossServer": [
 		{
-			"runtime": "${jbosstools.test.jboss.home.26.0}",
+			"runtime": "${jbosstools.test.jboss.home.26.1}",
 			"version": "24+",
 			"family": "WILDFLY"
 		}

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/PomServerConstants.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/PomServerConstants.java
@@ -13,7 +13,7 @@ package org.jboss.tools.as.ui.bot.itests.parametized.server;
 public class PomServerConstants {
 	// AUTOGEN_SERVER_ADAPTER_CHUNK
 	public static final String JBOSS_250_HOME="jbosstools.test.jboss.home.25.0";
-	public static final String JBOSS_260_HOME="jbosstools.test.jboss.home.26.0";
+	public static final String JBOSS_261_HOME="jbosstools.test.jboss.home.26.1";
 	// AUTOGEN_SERVER_ADAPTER_CHUNK
 	public static final String JBOSS_EAP_70_HOME="jbosstools.test.jboss.home.eap.7.0";
 	public static final String JBOSS_EAP_71_HOME="jbosstools.test.jboss.home.eap.7.1";
@@ -26,7 +26,7 @@ public class PomServerConstants {
 	public static final String[] PUBLIC = new String[]{
 			// AUTOGEN_SERVER_ADAPTER_CHUNK
 			JBOSS_250_HOME,
-			JBOSS_260_HOME,
+			JBOSS_261_HOME,
 			// AUTOGEN_SERVER_ADAPTER_CHUNK
 	};
 	// NEW_SERVER_ADAPTER
@@ -34,7 +34,7 @@ public class PomServerConstants {
 	public static final String[] ALL = new String[]{
 			// AUTOGEN_SERVER_ADAPTER_CHUNK
 			JBOSS_250_HOME,
-			JBOSS_260_HOME,
+			JBOSS_261_HOME,
 			// AUTOGEN_SERVER_ADAPTER_CHUNK
 			JBOSS_EAP_70_HOME, 
 			JBOSS_EAP_71_HOME,

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/ServerAdaptersTest.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/ServerAdaptersTest.java
@@ -47,7 +47,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
  *
  */
 @RunWith(RedDeerSuite.class)
-@JRE(cleanup=true)
+@JRE(cleanup=true, setDefault = true)
 @UseParametersRunnerFactory(ParameterizedRequirementsRunnerFactory.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ServerAdaptersTest extends AbstractTest {

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/ServerRuntimeUIConstants.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/ServerRuntimeUIConstants.java
@@ -61,10 +61,10 @@ public class ServerRuntimeUIConstants {
 	public static final String WF_20_0_0 = "WildFly 20.0.0 Final";
 	public static final String WF_21_0_0 = "WildFly 21.0.0 Final";
 	public static final String WF_22_0_0 = "WildFly 22.0.0 Final";
-	public static final String WF_23_0_0 = "WildFly 23.0.0 Final";
+	public static final String WF_23_0_2 = "WildFly 23.0.2 Final";
 	public static final String WF_24_0_0 = "WildFly 24.0.0 Final";
-	public static final String WF_25_0_0 = "WildFly 25.0.1 Final";
-	public static final String WF_26_0_0 = "WildFly 26.0.0 Final";
+	public static final String WF_25_0_1 = "WildFly 25.0.1 Final";
+	public static final String WF_26_1_1 = "WildFly 26.1.1 Final";
 	// AUTOGEN_SERVER_ADAPTER_CHUNK
 
 
@@ -78,6 +78,7 @@ public class ServerRuntimeUIConstants {
 	public static final String JBEAP_720 = "Red Hat JBoss EAP 7.2.0";
 	public static final String JBEAP_730 = "Red Hat JBoss EAP 7.3.0";
 	public static final String JBEAP_740 = "Red Hat JBoss EAP 7.4.0";
+	public static final String JBEAP_746 = "Red Hat JBoss EAP 7.4.6";
 	// AUTOGEN_SERVER_ADAPTER_CHUNK
 
 	
@@ -92,16 +93,16 @@ public class ServerRuntimeUIConstants {
 	
 	public static final String[] LATEST_MAJORS_FREE_DOWNLOADS = new String[] {
 			// AUTOGEN_SERVER_ADAPTER_CHUNK
-			WF_25_0_0,
-			WF_26_0_0,
+			WF_25_0_1,
+			WF_26_1_1,
 			// AUTOGEN_SERVER_ADAPTER_CHUNK
 	};
 
 	
 	public static final String[] FREE_DOWNLOADS = new String[] {
 			// AUTOGEN_SERVER_ADAPTER_CHUNK
-			WF_25_0_0,
-			WF_26_0_0,
+			WF_25_0_1,
+			WF_26_1_1,
 			// AUTOGEN_SERVER_ADAPTER_CHUNK
 	}; 
 
@@ -123,7 +124,7 @@ public class ServerRuntimeUIConstants {
 	public static final String[] SMOKETEST_DOWNLOADS = new String[] {
 			// AUTOGEN_SERVER_ADAPTER_CHUNK
 			JBEAP_740, 
-			WF_26_0_0,
+			WF_26_1_1,
 			// AUTOGEN_SERVER_ADAPTER_CHUNK
 	};
 
@@ -170,10 +171,10 @@ public class ServerRuntimeUIConstants {
 		addEntry(WF_20_0_0, 	"WildFly 20.0",			"20.0", "WildFly", 	"wildfly-20.0.0.Final",			STANDARD_DEPLOY, STANDARD_UNDEPLOY, wfEditorPorts());
 		addEntry(WF_21_0_0, 	"WildFly 21.0",			"21.0", "WildFly", 	"wildfly-21.0.1.Final",			STANDARD_DEPLOY, STANDARD_UNDEPLOY, wfEditorPorts());
 		addEntry(WF_22_0_0, 	"WildFly 22.0",			"22.0", "WildFly", 	"wildfly-22.0.0.Final",			STANDARD_DEPLOY, STANDARD_UNDEPLOY, wfEditorPorts());
-		addEntry(WF_23_0_0, 	"WildFly 23.0",			"23.0", "WildFly", 	"wildfly-23.0.0.Final",			STANDARD_DEPLOY, STANDARD_UNDEPLOY, wfEditorPorts());
+		addEntry(WF_23_0_2, 	"WildFly 23.0",			"23.0", "WildFly", 	"wildfly-23.0.2.Final",			STANDARD_DEPLOY, STANDARD_UNDEPLOY, wfEditorPorts());
 		addEntry(WF_24_0_0, 	"WildFly 24.0",			"24.0", "WildFly", 	"wildfly-24.0.0.Final",			STANDARD_DEPLOY, STANDARD_UNDEPLOY, wfEditorPorts());
-		addEntry(WF_25_0_0, 	"WildFly 25.0",			"25.0", "WildFly", 	"wildfly-25.0.1.Final",			STANDARD_DEPLOY, STANDARD_UNDEPLOY, wfEditorPorts());
-		addEntry(WF_26_0_0, 	"WildFly 26.0",			"26.0", "WildFly", 	"wildfly-26.0.0.Final",			STANDARD_DEPLOY, STANDARD_UNDEPLOY, wfEditorPorts());
+		addEntry(WF_25_0_1, 	"WildFly 25.0",			"25.0", "WildFly", 	"wildfly-25.0.1.Final",			STANDARD_DEPLOY, STANDARD_UNDEPLOY, wfEditorPorts());
+		addEntry(WF_26_1_1, 	"WildFly 26.1",			"26.1", "WildFly", 	"wildfly-26.1.1.Final",			STANDARD_DEPLOY, STANDARD_UNDEPLOY, wfEditorPorts());
 		// AUTOGEN_SERVER_ADAPTER_CHUNK
 		addEntry(JBEAP_610, 	"Red Hat JBoss EAP 6.1", "6.1",	"EAP", 		"jboss-eap-6.1", 				STANDARD_DEPLOY, STANDARD_UNDEPLOY, as7EditorPorts());
 		addEntry(JBEAP_620, 	"Red Hat JBoss EAP 6.2", "6.2",	"EAP", 		"jboss-eap-6.2", 				STANDARD_DEPLOY, STANDARD_UNDEPLOY, as7EditorPorts());
@@ -184,6 +185,7 @@ public class ServerRuntimeUIConstants {
 		addEntry(JBEAP_720, 	"Red Hat JBoss EAP 7.2", "7.2",	"EAP", 		"jboss-eap-7.2", 				STANDARD_DEPLOY, STANDARD_UNDEPLOY, wfEditorPorts());
 		addEntry(JBEAP_730, 	"Red Hat JBoss EAP 7.3", "7.3",	"EAP", 		"jboss-eap-7.3", 				STANDARD_DEPLOY, STANDARD_UNDEPLOY, wfEditorPorts());
 		addEntry(JBEAP_740, 	"Red Hat JBoss EAP 7.4", "7.4",	"EAP", 		"jboss-eap-7.4", 				STANDARD_DEPLOY, STANDARD_UNDEPLOY, wfEditorPorts());
+		addEntry(JBEAP_746, 	"Red Hat JBoss EAP 7.4.6","7.4","EAP", 	    "jboss-eap-7.4", 				STANDARD_DEPLOY, STANDARD_UNDEPLOY, wfEditorPorts());
 		// AUTOGEN_SERVER_ADAPTER_CHUNK
 		
 		addEntry(JPP_610, 		"JBoss Portal 6.1",		"6.1", "JPP", 		"jboss-jpp-6.1", 				STANDARD_DEPLOY, STANDARD_UNDEPLOY, as7EditorPorts());

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/ServerRuntimesTest.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/parametized/server/ServerRuntimesTest.java
@@ -84,7 +84,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 
 @RunWith(RedDeerSuite.class)
-@JRE(cleanup=true)
+@JRE(cleanup=true, setDefault = true)
 @UseParametersRunnerFactory(ParameterizedRequirementsRunnerFactory.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)//first acquireAndDetect, then detect, then operate
 @DisableSecureStorage

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/server/SingleServerAdaptersTest.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/server/SingleServerAdaptersTest.java
@@ -33,7 +33,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
  *
  */
 @RunWith(RedDeerSuite.class)
-@JRE(cleanup = true)
+@JRE(cleanup = true, setDefault = true)
 @UseParametersRunnerFactory(ParameterizedRequirementsRunnerFactory.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class SingleServerAdaptersTest extends ServerAdaptersTest {
@@ -47,7 +47,7 @@ public class SingleServerAdaptersTest extends ServerAdaptersTest {
 
 	@RequirementRestriction
 	public static RequirementMatcher getRestrictionMatcher() {
-	  return new RequirementMatcher(JRE.class, "version", new VersionMatcher("1.8"));
+	  return new RequirementMatcher(JRE.class, "version", new VersionMatcher("11"));
 	}
 
 	public SingleServerAdaptersTest(String server) {

--- a/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/server/SingleServerRuntimeTest.java
+++ b/as/itests/org.jboss.tools.as.ui.bot.itests/src/org/jboss/tools/as/ui/bot/itests/server/SingleServerRuntimeTest.java
@@ -20,7 +20,12 @@ import org.eclipse.reddeer.direct.preferences.Preferences;
 import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.Server;
 import org.eclipse.reddeer.eclipse.wst.server.ui.cnf.ServersView2;
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
+import org.eclipse.reddeer.requirements.jre.JRERequirement.JRE;
 import org.eclipse.reddeer.requirements.browser.InternalBrowserRequirement.UseInternalBrowser;
+import org.eclipse.reddeer.common.matcher.VersionMatcher;
+import org.eclipse.reddeer.junit.annotation.RequirementRestriction;
+import org.eclipse.reddeer.junit.internal.runner.ParameterizedRequirementsRunnerFactory;
+import org.eclipse.reddeer.junit.requirement.matcher.RequirementMatcher;
 import org.eclipse.ui.PlatformUI;
 import org.jboss.ide.eclipse.as.reddeer.server.view.JBossServer;
 import org.jboss.tools.as.ui.bot.itests.Activator;
@@ -37,6 +42,7 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 /**
  * This test is trying to optimize and clean up the huge number of tests that
@@ -47,6 +53,8 @@ import org.junit.runners.MethodSorters;
  */
 
 @RunWith(RedDeerSuite.class)
+@JRE(cleanup = true, setDefault = true)
+@UseParametersRunnerFactory(ParameterizedRequirementsRunnerFactory.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING) // first acquireAndDetect, then detect, then operate
 @DisableSecureStorage
 @UseInternalBrowser
@@ -56,6 +64,11 @@ public class SingleServerRuntimeTest {
 	private String serverName;
 	private String serverIdentification;
 
+	@RequirementRestriction
+	public static RequirementMatcher getRestrictionMatcher() {
+	  return new RequirementMatcher(JRE.class, "version", new VersionMatcher("11"));
+	}
+	
 	public SingleServerRuntimeTest() {
 		location = System.getProperty("jbosstools.test.single.runtime.location");
 		serverIdentification = System.getProperty("jbosstools.test.single.runtime.server.identification");
@@ -101,7 +114,7 @@ public class SingleServerRuntimeTest {
 				"jsp-project", ".war");
 		String depString = ServerRuntimeUIConstants.getDeployString(serverIdentification, "jsp-project",
 				".war");
-
+		
 		checkCountAndGetServerName();
 		OperateServerTemplate operate = new OperateServerTemplate(serverName);
 		operate.setUp();

--- a/as/itests/pom.xml
+++ b/as/itests/pom.xml
@@ -19,9 +19,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
 	<properties>
 		<enforceFailOnUIDependencyInCore>false</enforceFailOnUIDependencyInCore>
+		<jbosstools.test.jboss.home.23.0>${requirementsDirectory}/wildfly-23.0.2.Final</jbosstools.test.jboss.home.23.0>
 		<jbosstools.test.jboss.home.24.0>${requirementsDirectory}/wildfly-24.0.0.Final</jbosstools.test.jboss.home.24.0>
 		<jbosstools.test.jboss.home.25.0>${requirementsDirectory}/wildfly-25.0.1.Final</jbosstools.test.jboss.home.25.0>
-		<jbosstools.test.jboss.home.26.0>${requirementsDirectory}/wildfly-26.0.0.Final</jbosstools.test.jboss.home.26.0>
+		<jbosstools.test.jboss.home.26.1>${requirementsDirectory}/wildfly-26.1.1.Final</jbosstools.test.jboss.home.26.1>
 		<jbosstools.test.jboss.home.eap.7.0>${requirementsDirectory}/jboss-eap-7.0</jbosstools.test.jboss.home.eap.7.0>
 		<jbosstools.test.jboss.home.eap.7.1>${requirementsDirectory}/jboss-eap-7.1</jbosstools.test.jboss.home.eap.7.1>
 		<jbosstools.test.jboss.home.eap.7.2>${requirementsDirectory}/jboss-eap-7.2</jbosstools.test.jboss.home.eap.7.2>
@@ -30,7 +31,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 		<additionalProperties></additionalProperties>
 		<!-- skipPrivateRequirements and skipTestsWithPrivateRequirements are inherited from parent pom -->
 		<runtimes.suite.scope>smoke</runtimes.suite.scope>
-		<systemProperties>-Djbosstools.test.jre.8=${jbosstools.test.jre.8} -Djbosstools.test.jre.11=${jbosstools.test.jre.11} -Djbosstools.test.jre.17=${jbosstools.test.jre.17} -Djbosstools.test.jboss.home.24.0=${jbosstools.test.jboss.home.24.0} -Djbosstools.test.jboss.home.25.0=${jbosstools.test.jboss.home.25.0} -Djbosstools.test.jboss.home.26.0=${jbosstools.test.jboss.home.26.0}  -Djbosstools.test.jboss.home.eap.7.0=${jbosstools.test.jboss.home.eap.7.0} -Djbosstools.test.jboss.home.eap.7.1=${jbosstools.test.jboss.home.eap.7.1} -Djbosstools.test.jboss.home.eap.7.2=${jbosstools.test.jboss.home.eap.7.2} -Djbosstools.test.jboss.home.eap.7.3=${jbosstools.test.jboss.home.eap.7.3} -Djbosstools.test.jboss.home.eap.7.4=${jbosstools.test.jboss.home.eap.7.4} -Dorg.jboss.tools.tests.skipPrivateRequirements=${skipPrivateRequirements} -Dorg.jboss.tools.tests.skipTestsWithPrivateRequirements=${skipTestsWithPrivateRequirements} -Djboss.org.username=${jboss.org.username} -Djboss.org.password=${jboss.org.password} -Djbosstools.test.singleruntime.location=${jbosstools.test.singleruntime.location} -Druntimes.suite.scope=${runtimes.suite.scope} ${additionalProperties}</systemProperties>
+		<systemProperties>-Djbosstools.test.jre.8=${jbosstools.test.jre.8} -Djbosstools.test.jre.11=${jbosstools.test.jre.11} -Djbosstools.test.jre.17=${jbosstools.test.jre.17} -Djbosstools.test.jboss.home.23.0=${jbosstools.test.jboss.home.23.0} -Djbosstools.test.jboss.home.24.0=${jbosstools.test.jboss.home.24.0} -Djbosstools.test.jboss.home.25.0=${jbosstools.test.jboss.home.25.0} -Djbosstools.test.jboss.home.26.1=${jbosstools.test.jboss.home.26.1}  -Djbosstools.test.jboss.home.eap.7.0=${jbosstools.test.jboss.home.eap.7.0} -Djbosstools.test.jboss.home.eap.7.1=${jbosstools.test.jboss.home.eap.7.1} -Djbosstools.test.jboss.home.eap.7.2=${jbosstools.test.jboss.home.eap.7.2} -Djbosstools.test.jboss.home.eap.7.3=${jbosstools.test.jboss.home.eap.7.3} -Djbosstools.test.jboss.home.eap.7.4=${jbosstools.test.jboss.home.eap.7.4} -Dorg.jboss.tools.tests.skipPrivateRequirements=${skipPrivateRequirements} -Dorg.jboss.tools.tests.skipTestsWithPrivateRequirements=${skipTestsWithPrivateRequirements} -Djboss.org.username=${jboss.org.username} -Djboss.org.password=${jboss.org.password} -Djbosstools.test.singleruntime.location=${jbosstools.test.singleruntime.location} -Druntimes.suite.scope=${runtimes.suite.scope} ${additionalProperties}</systemProperties>
 	</properties>
 
 	<build>
@@ -188,6 +189,19 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 								</configuration>
 							</execution>
 							<execution>
+								<id>install-wildfly-23.0.2.Final</id>
+								<phase>pre-integration-test</phase>
+								<goals>
+									<goal>wget</goal>
+								</goals>
+								<configuration>
+									<url>https://download.jboss.org/wildfly/23.0.2.Final/wildfly-23.0.2.Final.zip</url>
+									<sha1>d53d68d6c2aedbc7de4c155c5bbd348b6e9ef023</sha1>
+									<unpack>true</unpack>
+									<skip>${skipTestsOrITests}</skip>
+								</configuration>
+							</execution>
+							<execution>
 								<id>install-wildfly-24.0.0.Final</id>
 								<phase>pre-integration-test</phase>
 								<goals>
@@ -214,14 +228,14 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 								</configuration>
 							</execution>
 							<execution>
-								<id>install-wildfly-26.0.0.Final</id>
+								<id>install-wildfly-26.1.1.Final</id>
 								<phase>pre-integration-test</phase>
 								<goals>
 									<goal>wget</goal>
 								</goals>
 								<configuration>
-									<url>https://github.com/wildfly/wildfly/releases/download/26.0.0.Final/wildfly-26.0.0.Final.zip</url>
-									<sha1>9b0ad3a6434750e4bf8def46aa0dbe19dd699b37</sha1>
+									<url>https://github.com/wildfly/wildfly/releases/download/26.1.1.Final/wildfly-26.1.1.Final.zip</url>
+									<sha1>8c76263c93ee4fa96cde1d7acca68b57a99b1df0</sha1>
 									<unpack>true</unpack>
 									<skip>${skipTestsOrITests}</skip>
 								</configuration>


### PR DESCRIPTION
wf26.1.1 and 25.0.1, eap7.4.0 and 7.4.6 Single itest for server-itests, server-eap-itests and server-smoke-itests.

Signed-off-by: Oleksii Korniienko <olkornii@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
