### PR TITLE
RSP server processes look bad in debug view

### DIFF
--- a/as/plugins/org.jboss.tools.as.rsp.ui/plugin.xml
+++ b/as/plugins/org.jboss.tools.as.rsp.ui/plugin.xml
@@ -96,4 +96,13 @@
          </enablement>
       </actionProvider>
    </extension>
+   <extension
+         point="org.eclipse.debug.core.launchConfigurationTypes">
+      <launchConfigurationType
+            id="org.jboss.tools.as.rsp.ui.launchConfigurationType1"
+            modes="run,debug"
+            name="Server"
+            public="false">
+      </launchConfigurationType>
+   </extension>
 </plugin>


### PR DESCRIPTION
# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

![image](https://github.com/jbosstools/jbosstools-server/assets/630383/46251b13-14d6-4d4c-ac77-5793814ef18b)

Launch and processes have no known name. 

![image](https://github.com/jbosstools/jbosstools-server/assets/630383/0e2121c3-7a80-4796-89e7-6a09cd0ec7eb)

Also, when checking the process details, there's no information. 

We are also missing the command line that was used to launch, but, unfortunately I can't get that right now without further changes. 

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
